### PR TITLE
Add package.json with dependencies and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "aegir-bot",
+  "version": "1.0.0",
+  "description": "",
+  "main": "bot.js",
+  "scripts": {
+    "start": "node bot.js",
+    "deploy": "node deploy-commands.js",
+    "backup": "node backupFirestore.js",
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "engines": {
+    "node": "18.16.0"
+  },
+  "dependencies": {
+    "axios": "^1.5.1",
+    "discord.js": "^14.13.0",
+    "firebase-admin": "^12.3.1",
+    "node-fetch": "^3.3.1",
+    "openai": "^4.25.0"
+  }
+}


### PR DESCRIPTION
## Summary
- create package.json using npm init
- add scripts for starting bot, deploying commands, backing up Firestore, and placeholder tests
- declare dependencies from existing lockfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e293c0fb0832ea65e74be3dec86af