### PR TITLE
refactor: unify guild identifier

### DIFF
--- a/clientManager.js
+++ b/clientManager.js
@@ -5,12 +5,12 @@ class clientManager {
         //Remove spaces
         emojiName = emojiName.replace(/\s/g, '');
         const client = bot.getClient();
-        const guildID = bot.getGuildID();
+        const guildId = bot.getGuildID();
         if (!client) {
             console.log("Client not found")
             return null;
         }
-        const guild = client.guilds.cache.get(guildID);
+        const guild = client.guilds.cache.get(guildId);
         if (!guild) {
             console.log("Guild not found")
             return null;
@@ -26,8 +26,8 @@ class clientManager {
     static async getUser(userID) {
         const bot = require('./bot');
         const client = bot.getClient();
-        const guildID = bot.getGuildID();
-        const guild = client.guilds.cache.get(guildID);
+        const guildId = bot.getGuildID();
+        const guild = client.guilds.cache.get(guildId);
         if (!guild) {
             console.log("Guild not found")
             return null;

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -2,8 +2,8 @@ const shop = require('./shop');
 const char = require('./char');
 const marketplace = require('./marketplace');
 const admin = require('./admin');
-//Import guildID from config.json
-const { guildID } = require('./config.json');
+//Import guildId from config.json
+const { guildId } = require('./config.json');
 
 // MODALS
 addItem = async (interaction) => {


### PR DESCRIPTION
## Summary
- replace guildID import with guildId in interaction handler
- switch client manager to reference guildId naming consistently
- ensure modules share guildId from configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e7bd2bc1c832ebc025577eff0adef