### PR TITLE
Add configurable tokens with env fallback

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,4 +1,4 @@
-const {clientId, guildId, token} = require('./config.json');
+const { clientId, guildId, token } = require('./config');
 const Discord = require('discord.js');
 const fs = require('node:fs');
 const path = require('node:path');

--- a/char.js
+++ b/char.js
@@ -3,7 +3,7 @@ const shop = require('./shop');
 const clientManager = require('./clientManager');
 const axios = require('axios');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, createWebhook } = require('discord.js');
-const { clientId, guildId } = require('./config.json');
+const { clientId, guildId } = require('./config');
 
 class char {
   static async warn(playerID) {

--- a/chatGPT.js
+++ b/chatGPT.js
@@ -1,8 +1,9 @@
 const OpenAI = require ('openai');
 const dbm = require('./database-manager');
 
-//Api key is in config.json, fourth element named gpt token. Grab it as constant
-const apiKey = require('./config.json').gptToken;
+// Api key is in config.json or environment variables (gptToken)
+const { gptToken } = require('./config');
+const apiKey = gptToken;
 //Format to work as gpt key
 //const apiToken = "Bearer " + apiKey;
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,6 @@
+{
+  "clientId": "YOUR_CLIENT_ID",
+  "guildId": "YOUR_GUILD_ID",
+  "token": "YOUR_BOT_TOKEN",
+  "gptToken": "YOUR_OPENAI_TOKEN"
+}

--- a/config.js
+++ b/config.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+let config = {};
+const configPath = path.join(__dirname, 'config.json');
+
+if (fs.existsSync(configPath)) {
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    config = JSON.parse(raw);
+  } catch (err) {
+    console.error('Failed to read config.json:', err);
+  }
+}
+
+module.exports = {
+  clientId: process.env.CLIENT_ID || config.clientId,
+  guildId: process.env.GUILD_ID || config.guildId,
+  token: process.env.DISCORD_TOKEN || config.token,
+  gptToken: process.env.GPT_TOKEN || config.gptToken,
+};

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,5 +1,5 @@
 const { REST, Routes, SlashCommandBuilder } = require('discord.js');
-const { clientId, guildId, token } = require('./config.json');
+const { clientId, guildId, token } = require('./config');
 const fs = require('node:fs');
 const path = require('node:path');
 const dbm = require('./database-manager');

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -2,8 +2,8 @@ const shop = require('./shop');
 const char = require('./char');
 const marketplace = require('./marketplace');
 const admin = require('./admin');
-//Import guildID from config.json
-const { guildID } = require('./config.json');
+// Import guildId from config or environment variables
+const { guildId } = require('./config');
 
 // MODALS
 addItem = async (interaction) => {


### PR DESCRIPTION
## Summary
- add configuration loader that reads config.json or environment variables
- switch bot files to use new config helper
- provide example config template for deployment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e7bd7b5d0832e923b9c0d3af07075