### PR TITLE
feat: add environment aware config loader

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+// Load local configuration if available
+let cfg = {};
+const cfgPath = path.join(__dirname, 'config.json');
+if (fs.existsSync(cfgPath)) {
+  try {
+    const localCfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    if (localCfg && typeof localCfg === 'object') {
+      Object.assign(cfg, localCfg);
+    }
+  } catch (err) {
+    console.error('Failed to parse config.json:', err);
+  }
+}
+
+// Environment variables have priority
+const keys = ['DISCORD_TOKEN', 'OPENAI_API_KEY', 'CLIENT_ID', 'GUILD_ID', 'ADMIN_ID'];
+for (const key of keys) {
+  if (process.env[key]) {
+    cfg[key] = process.env[key];
+  }
+}
+
+module.exports = cfg;


### PR DESCRIPTION
## Summary
- add `config.js` that reads environment variables and merges with optional `config.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e87825684832ea7eec7a4f4cce834