### PR TITLE
refactor: centralize config import

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -6,7 +6,7 @@
  *      CLIENT_ID       – the application / client ID
  *      GUILD_ID        – the test-server ID (for slash-command registration)
  *
- *  • In local dev you can still drop a config.json next to this file:
+ *  • In local dev you can still drop a config file next to this file:
  *      { "token":"...", "clientId":"...", "guildId":"..." }
  */
 
@@ -15,7 +15,7 @@ const path = require('node:path');
 const { Client, GatewayIntentBits, Collection, Events } = require('discord.js');
 
 // ────────────────────────────────────────────────────────────────
-// 1) Load secrets from ENV, else fall back to ./config.json
+// 1) Load secrets from ENV, else fall back to ./config
 // ────────────────────────────────────────────────────────────────
 let token   = process.env.DISCORD_TOKEN;
 let clientId = process.env.CLIENT_ID;
@@ -23,14 +23,14 @@ let guildId  = process.env.GUILD_ID;
 
 if (!token || !clientId || !guildId) {
   try {
-    const local = require('./config.json');
-    token    ||= local.token;
-    clientId ||= local.clientId;
-    guildId  ||= local.guildId;
-    console.log('[INFO] Using values from config.json (dev mode)');
+    const { token: localToken, clientId: localClientId, guildId: localGuildId } = require('./config');
+    token    ||= localToken;
+    clientId ||= localClientId;
+    guildId  ||= localGuildId;
+    console.log('[INFO] Using values from config (dev mode)');
   } catch {
     console.warn(
-      '[WARN] No ENV vars and no config.json found. ' +
+      '[WARN] No ENV vars and no config file found. ' +
       'Set DISCORD_TOKEN / CLIENT_ID / GUILD_ID!'
     );
   }

--- a/char.js
+++ b/char.js
@@ -3,7 +3,6 @@ const shop = require('./shop');
 const clientManager = require('./clientManager');
 const axios = require('axios');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, createWebhook } = require('discord.js');
-const { clientId, guildId } = require('./config.json');
 
 class char {
   static async warn(playerID) {

--- a/chatGPT.js
+++ b/chatGPT.js
@@ -1,8 +1,7 @@
 const OpenAI = require ('openai');
 const dbm = require('./database-manager');
 
-//Api key is in config.json, fourth element named gpt token. Grab it as constant
-const apiKey = require('./config.json').gptToken;
+const { gptToken: apiKey } = require('./config');
 //Format to work as gpt key
 //const apiToken = "Bearer " + apiKey;
 

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,5 +1,5 @@
 const { REST, Routes, SlashCommandBuilder } = require('discord.js');
-const { clientId, guildId, token } = require('./config.json');
+const { clientId, guildId, token } = require('./config');
 const fs = require('node:fs');
 const path = require('node:path');
 const dbm = require('./database-manager');

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -2,8 +2,8 @@ const shop = require('./shop');
 const char = require('./char');
 const marketplace = require('./marketplace');
 const admin = require('./admin');
-//Import guildId from config.json
-const { guildId } = require('./config.json');
+// Configuration
+// (no config values currently required here)
 
 // MODALS
 addItem = async (interaction) => {


### PR DESCRIPTION
## Summary
- load deployment config from a generic `config` module
- simplify interaction handler and character module config usage
- destructure config values where needed and clean up config comments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e87839ee0832e8b450a34914d1a84