### PR TITLE
refactor: unify OpenAI API key

### DIFF
--- a/chatGPT.js
+++ b/chatGPT.js
@@ -1,13 +1,11 @@
 const OpenAI = require ('openai');
 const dbm = require('./database-manager');
 
-//Api key is in config.json, fourth element named gpt token. Grab it as constant
-const apiKey = require('./config.json').gptToken;
-//Format to work as gpt key
-//const apiToken = "Bearer " + apiKey;
+// Load the OpenAI API key from our central config file
+const { openaiKey } = require('./config.js');
 
-
-const openai = new OpenAI({apiKey: apiKey});
+// Initialize OpenAI with the standard key name
+const openai = new OpenAI({ apiKey: openaiKey });
 const Model3_5Turbo = "gpt-3.5-turbo";
 const Model4o = "gpt-4o";
 

--- a/config.js
+++ b/config.js
@@ -1,0 +1,18 @@
+// Central configuration module
+// Exposes common configuration values read from environment variables or local config.json
+
+let openaiKey = process.env.OPENAI_API_KEY;
+
+if (!openaiKey) {
+  try {
+    const local = require('./config.json');
+    // Support both new and legacy property names
+    openaiKey = local.openaiKey || local.gptToken;
+  } catch {
+    // No local config file found
+  }
+}
+
+module.exports = {
+  openaiKey,
+};


### PR DESCRIPTION
## Summary
- add config.js to expose a single `openaiKey` from env or local config
- update chatGPT.js to consume `openaiKey` for OpenAI initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e8785fba4832ea8dcc51178af5b00