### PR TITLE
use config.js for runtime secrets

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,11 +15,24 @@ if (fs.existsSync(cfgPath)) {
   }
 }
 
-// Environment variables have priority
-const keys = ['DISCORD_TOKEN', 'OPENAI_API_KEY', 'CLIENT_ID', 'GUILD_ID', 'ADMIN_ID'];
-for (const key of keys) {
-  if (process.env[key]) {
-    cfg[key] = process.env[key];
+// Environment variables have priority.  Normalize so callers can use either
+// upper- or lower-case keys (e.g. `CLIENT_ID` or `clientId`).
+const mappings = {
+  DISCORD_TOKEN: 'token',
+  OPENAI_API_KEY: 'openaiApiKey',
+  CLIENT_ID: 'clientId',
+  GUILD_ID: 'guildId',
+  ADMIN_ID: 'adminId',
+};
+
+for (const [envKey, alias] of Object.entries(mappings)) {
+  if (process.env[envKey]) {
+    cfg[envKey] = process.env[envKey];
+    cfg[alias] = process.env[envKey];
+  } else if (cfg[alias]) {
+    cfg[envKey] = cfg[alias];
+  } else if (cfg[envKey]) {
+    cfg[alias] = cfg[envKey];
   }
 }
 

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,5 +1,6 @@
 const { REST, Routes, SlashCommandBuilder } = require('discord.js');
-const { clientId, guildId, token } = require('./config.json');
+// Load credentials from config.js (env vars take priority over config.json)
+const { clientId, guildId, token } = require('./config.js');
 const fs = require('node:fs');
 const path = require('node:path');
 const dbm = require('./database-manager');

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -2,8 +2,8 @@ const shop = require('./shop');
 const char = require('./char');
 const marketplace = require('./marketplace');
 const admin = require('./admin');
-//Import guildId from config.json
-const { guildId } = require('./config.json');
+// Import guildId from config.js (environment variables take priority)
+const { guildId } = require('./config.js');
 
 // MODALS
 addItem = async (interaction) => {


### PR DESCRIPTION
## Summary
- switch interaction handler and command deployer to pull secrets from config.js
- normalize config.js so ENV vars or optional config.json both provide token/client/guild IDs
- remove hard dependency on config.json

## Testing
- `npm test`
- `node bot.js` (fails for invalid token but no missing config.json)


------
https://chatgpt.com/codex/tasks/task_e_688ea05563ac832e86591e9b0a3526ca