### PR TITLE
refactor: remove async IIFE pattern in command execute functions

### DIFF
--- a/commands/adminCommands/addIncome.js
+++ b/commands/adminCommands/addIncome.js
@@ -19,8 +19,6 @@ module.exports = {
     async execute(interaction) {
         const role = interaction.options.getRole('role');
         const income = interaction.options.getString('income');
-
-        (async () => {
             //addIncome(roleID, incomeString)
             let reply = await admin.addIncome(role, income);
             if (typeof(reply) == 'string') {
@@ -29,6 +27,5 @@ module.exports = {
                 await interaction.reply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
-        })()
     }
 };

--- a/commands/adminCommands/editembedmenu.js
+++ b/commands/adminCommands/editembedmenu.js
@@ -23,8 +23,6 @@ module.exports = {
     async execute(interaction) {
         const role = interaction.options.getString('embed');
         const type = interaction.options.getString('type');
-
-        (async () => {
             //addIncome(roleID, incomeString)
             let reply = await admin.editMapMenu(role, interaction.user.tag, type);
             if (typeof(reply) == 'string') {
@@ -33,6 +31,5 @@ module.exports = {
                 await interaction.reply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
-        })()
     }
 };

--- a/commands/adminCommands/editincomemenu.js
+++ b/commands/adminCommands/editincomemenu.js
@@ -13,8 +13,6 @@ module.exports = {
         ),
     async execute(interaction) {
         const role = interaction.options.getString('income');
-
-        (async () => {
             //addIncome(roleID, incomeString)
             let reply = await admin.editIncomeMenu(role, interaction.user.tag);
             if (typeof(reply) == 'string') {
@@ -23,6 +21,5 @@ module.exports = {
                 await interaction.reply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
-        })()
     }
 };

--- a/commands/adminCommands/guide.js
+++ b/commands/adminCommands/guide.js
@@ -10,10 +10,8 @@ module.exports = {
 			.setDescription('The guide name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const guideName = interaction.options.getString('guide');
-
-		(async () => {
             let returnEmbed = await admin.map(guideName, interaction.channelId, "guide");
 
 			// If the return is a string, it's an error message
@@ -24,6 +22,5 @@ module.exports = {
                 await interaction.reply({ embeds: [returnEmbed] });
             }
 			// Call the addItem function from the Shop class
-		})()
 	},
 };

--- a/commands/adminCommands/lore.js
+++ b/commands/adminCommands/lore.js
@@ -10,10 +10,8 @@ module.exports = {
 			.setDescription('The lore name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const loreName = interaction.options.getString('lore');
-
-		(async () => {
             let returnEmbed = await admin.map(loreName, interaction.channelId, "lore");
 
 			// If the return is a string, it's an error message
@@ -24,6 +22,5 @@ module.exports = {
                 await interaction.reply({ embeds: [returnEmbed] });
             }
 			// Call the addItem function from the Shop class
-		})()
 	},
 };

--- a/commands/adminCommands/map.js
+++ b/commands/adminCommands/map.js
@@ -10,10 +10,8 @@ module.exports = {
 			.setDescription('The map name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const mapName = interaction.options.getString('map');
-
-		(async () => {
             let returnEmbed = await admin.map(mapName, interaction.channelId);
 
 			// If the return is a string, it's an error message
@@ -24,6 +22,5 @@ module.exports = {
                 await interaction.reply({ embeds: [returnEmbed] });
             }
 			// Call the addItem function from the Shop class
-		})()
 	},
 };

--- a/commands/adminCommands/rank.js
+++ b/commands/adminCommands/rank.js
@@ -10,10 +10,8 @@ module.exports = {
 			.setDescription('The rank name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const rankName = interaction.options.getString('rank');
-
-		(async () => {
             let returnEmbed = await admin.map(rankName, interaction.channelId, "rank");
 
 			// If the return is a string, it's an error message
@@ -24,6 +22,5 @@ module.exports = {
                 await interaction.reply({ embeds: [returnEmbed] });
             }
 			// Call the addItem function from the Shop class
-		})()
 	},
 };

--- a/commands/adminCommands/removeembed.js
+++ b/commands/adminCommands/removeembed.js
@@ -20,11 +20,9 @@ module.exports = {
                     {name: 'Lore', value: 'lore'},
                     {name: 'Rank', value: 'rank'},
                     {name: 'Guide', value: 'guide'})),
-	execute(interaction) {
+	async execute(interaction) {
 		const mapName = interaction.options.getString('embed');
 		const type = interaction.options.getString('type');
-
-		(async () => {
             let returnString = await admin.removeMap(mapName, type);
 
 			if (returnString) {
@@ -34,6 +32,5 @@ module.exports = {
 				await interaction.reply(`${capitalType} '${mapName}' has been removed.`);
 			}
 			// Call the addItem function from the Shop class
-		})()
 	},
 };

--- a/commands/adminCommands/removeincome.js
+++ b/commands/adminCommands/removeincome.js
@@ -11,10 +11,8 @@ module.exports = {
             .setDescription('The income name')
             .setRequired(true)
         ),
-    execute(interaction) {
+    async execute(interaction) {
         const itemName = interaction.options.getString('income');
-
-        (async () => {
             let returnString = await shop.removeIncome(itemName);
 
 			if (returnString) {
@@ -23,6 +21,5 @@ module.exports = {
 				await interaction.reply(`Income '${itemName}' has been removed.`);
 			}
             // Call the addItem function from the Shop class
-        })()
     },
 };

--- a/commands/adminCommands/removerecipe.js
+++ b/commands/adminCommands/removerecipe.js
@@ -11,10 +11,8 @@ module.exports = {
 			.setDescription('The recipe name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const itemName = interaction.options.getString('recipe');
-
-		(async () => {
             let returnString = await shop.removeRecipe(itemName);
 
 			if (returnString) {
@@ -23,6 +21,5 @@ module.exports = {
 				await interaction.reply(`Recipe '${itemName}' has been removed.`);
 			}
 			// Call the addItem function from the Shop class
-		})()
 	},
 };

--- a/commands/charCommands/balance.js
+++ b/commands/charCommands/balance.js
@@ -5,16 +5,13 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('balance')
 		.setDescription('Show balance'),
-	execute(interaction) {
+	async execute(interaction) {
 		const charID = interaction.user.tag;
-
-		(async () => {
             let replyEmbed = await char.balance(charID);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply({ embeds: [replyEmbed] });
             }
-		})()
 	},
 };

--- a/commands/charCommands/balanceadmin.js
+++ b/commands/charCommands/balanceadmin.js
@@ -12,14 +12,11 @@ module.exports = {
 		const charResponse = interaction.options.getUser('player').toString();
         const charNumeric = charResponse.substring(2, charResponse.length - 1);
 		const charID = await dataGetters.getCharFromNumericID(charNumeric);
-
-		(async () => {
             let replyEmbed = await char.balance(charID);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply({ embeds: [replyEmbed] });
             }
-		})()
 	},
 };

--- a/commands/charCommands/balanceall.js
+++ b/commands/charCommands/balanceall.js
@@ -6,9 +6,7 @@ module.exports = {
 		.setName('balanceall')
 		.setDescription('Show balance of all players')
         .setDefaultMemberPermissions(0),
-	execute(interaction) {
-
-		(async () => {
+	async execute(interaction) {
             let [replyEmbed, replyRows] = await char.balanceAll(1);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
@@ -16,6 +14,5 @@ module.exports = {
                 //Has action rows
                 await interaction.reply({ embeds: [replyEmbed], components: replyRows});
             }
-		})()
 	},
 };

--- a/commands/charCommands/bank.js
+++ b/commands/charCommands/bank.js
@@ -5,16 +5,13 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('bank')
 		.setDescription('Show bank'),
-	execute(interaction) {
+	async execute(interaction) {
 		const charID = interaction.user.tag;
-
-		(async () => {
             let replyEmbed = await char.bank(charID);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply({ embeds: [replyEmbed] });
             }
-		})()
 	},
 };

--- a/commands/charCommands/char.js
+++ b/commands/charCommands/char.js
@@ -5,16 +5,13 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('char')
 		.setDescription('Show player character'),
-	execute(interaction) {
+	async execute(interaction) {
 		const charID = interaction.user.tag;
-
-		(async () => {
             let replyEmbed = await char.char(charID);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply({ embeds: [replyEmbed] });
             }
-		})()
 	},
 };

--- a/commands/charCommands/charadmin.js
+++ b/commands/charCommands/charadmin.js
@@ -17,14 +17,11 @@ module.exports = {
 		//char is a string starting with <@ and ending with >
 		const charNumeric = charResponse.substring(2, charResponse.length - 1);
 		const charID = await dataGetters.getCharFromNumericID(charNumeric);
-
-		(async () => {
             let replyEmbed = await char.char(charID);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply({ embeds: [replyEmbed] });
             }
-		})()
 	},
 };

--- a/commands/charCommands/craft.js
+++ b/commands/charCommands/craft.js
@@ -10,10 +10,8 @@ module.exports = {
 			.setDescription('The recipe name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const recipe = interaction.options.getString('recipe');
-
-		(async () => {
             let reply = await char.craft(interaction.user, recipe, interaction.guild)
             if (typeof(reply) == 'string') {
                 await interaction.reply(reply);
@@ -21,6 +19,5 @@ module.exports = {
                 await interaction.reply({ embeds: [reply] });
             }
 			// Call the useItem function from the Shop class
-		})()
 	},
 };

--- a/commands/charCommands/deposit.js
+++ b/commands/charCommands/deposit.js
@@ -9,17 +9,14 @@ module.exports = {
             option.setName('quantity')
                 .setDescription('Quantity to deposit')
                 .setRequired(true)),
-	execute(interaction) {
+	async execute(interaction) {
 		const charID = interaction.user.tag;
         const quantity = interaction.options.getInteger('quantity');
-
-		(async () => {
             let replyEmbed = await char.deposit(charID, quantity);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply("Deposited " + quantity + " gold to bank");
             }
-		})()
 	},
 };

--- a/commands/charCommands/grab.js
+++ b/commands/charCommands/grab.js
@@ -13,18 +13,15 @@ module.exports = {
             option.setName('quantity')
                 .setDescription('Quantity to grab')
                 .setRequired(true)),
-	execute(interaction) {
+	async execute(interaction) {
 		const charID = interaction.user.tag;
         const item = interaction.options.getString('item');
         const quantity = interaction.options.getInteger('quantity');
-
-		(async () => {
             let replyEmbed = await char.grab(charID, item, quantity);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply("Grabbed " + quantity + " " + item + " from storage");
             }
-		})()
 	},
 };

--- a/commands/charCommands/me.js
+++ b/commands/charCommands/me.js
@@ -5,16 +5,13 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('me')
 		.setDescription('Show player character- only RP aspects'),
-	execute(interaction) {
+	async execute(interaction) {
 		const charID = interaction.user.tag;
-
-		(async () => {
             let replyEmbed = await char.me(charID);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply({ embeds: [replyEmbed] });
             }
-		})()
 	},
 };

--- a/commands/charCommands/say.js
+++ b/commands/charCommands/say.js
@@ -10,10 +10,8 @@ module.exports = {
 			.setDescription('The message to send')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
         const message = interaction.options.getString('message');
-
-		(async () => {
             let reply = await char.say(interaction.user.tag, message, interaction.channel)
             if (typeof(reply) == 'string') {
                 await interaction.reply({ content: reply, ephemeral: true });
@@ -21,6 +19,5 @@ module.exports = {
                 await interaction.reply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
-        })()
 	},
 };

--- a/commands/charCommands/setavatar.js
+++ b/commands/charCommands/setavatar.js
@@ -10,13 +10,10 @@ module.exports = {
 			.setDescription('URL of your avatar')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const avatarURL = interaction.options.getString('avatarurl');
 		const userID = interaction.user.tag;
-
-		(async () => {
 			let replyString = await char.setAvatar(avatarURL, userID)
 			await interaction.reply(replyString);
-		})()
 	},
 };

--- a/commands/charCommands/stats.js
+++ b/commands/charCommands/stats.js
@@ -5,16 +5,13 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('stats')
 		.setDescription('Show player stats'),
-	execute(interaction) {
+	async execute(interaction) {
 		const charID = interaction.user.tag;
-
-		(async () => {
             let replyEmbed = await char.stats(charID);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply({ embeds: [replyEmbed] });
             }
-		})()
 	},
 };

--- a/commands/charCommands/store.js
+++ b/commands/charCommands/store.js
@@ -13,18 +13,15 @@ module.exports = {
             option.setName('quantity')
                 .setDescription('Quantity to store')
                 .setRequired(true)),
-	execute(interaction) {
+	async execute(interaction) {
 		const charID = interaction.user.tag;
         const item = interaction.options.getString('item');
         const quantity = interaction.options.getInteger('quantity');
-
-		(async () => {
             let replyEmbed = await char.store(charID, item, quantity);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply("Stored " + quantity + " " + item + " to storage");
             }
-		})()
 	},
 };

--- a/commands/charCommands/useitem.js
+++ b/commands/charCommands/useitem.js
@@ -15,11 +15,9 @@ module.exports = {
 			.setDescription('How many do you want to buy (Leave blank for 1)')
 			.setRequired(false)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const itemName = interaction.options.getString('itemname');
         const numberItems = interaction.options.getInteger('numbertouse');
-
-		(async () => {
             let reply = await char.useItem(itemName, interaction.user.tag, numberItems)
             if (typeof(reply) == 'string') {
                 await interaction.reply(reply);
@@ -27,6 +25,5 @@ module.exports = {
                 await interaction.reply({ embeds: [reply] });
             }
 			// Call the useItem function from the Shop class
-		})()
 	},
 };

--- a/commands/charCommands/withdraw.js
+++ b/commands/charCommands/withdraw.js
@@ -9,17 +9,14 @@ module.exports = {
             option.setName('quantity')
                 .setDescription('Quantity to withdraw')
                 .setRequired(true)),
-	execute(interaction) {
+	async execute(interaction) {
 		const charID = interaction.user.tag;
         const quantity = interaction.options.getInteger('quantity');
-
-		(async () => {
             let replyEmbed = await char.withdraw(charID, quantity);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply(replyEmbed);
             } else {
                 await interaction.reply("Withdrew " + quantity + " gold from bank");
             }
-		})()
 	},
 };

--- a/commands/helpCommands/inspectrecipe.js
+++ b/commands/helpCommands/inspectrecipe.js
@@ -12,8 +12,6 @@ module.exports = {
         ),
     async execute(interaction) {
         const recipe = interaction.options.getString('recipe');
-
-        (async () => {
             let reply = await shop.inspectRecipe(recipe)
             if (typeof(reply) == 'string') {
                 // Ephemeral reply
@@ -22,6 +20,5 @@ module.exports = {
                 await interaction.reply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
-        })()
     },
 };

--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -25,14 +25,11 @@ module.exports = {
         const itemName = interaction.options.getString('itemname');
         const quantity = interaction.options.getInteger('quantity');
         const price = interaction.options.getInteger('price');
-
-        (async () => {
             let reply = await marketplace.postSale(quantity, itemName, price, interaction.user.tag, interaction.user.id)
             if (typeof (reply) == 'string') {
                 await interaction.reply(reply);
             } else {
                 await interaction.reply({ embeds: [reply] });
             }
-        })()
     }
 };

--- a/commands/shopCommands/buyitem.js
+++ b/commands/shopCommands/buyitem.js
@@ -15,14 +15,11 @@ module.exports = {
 			.setDescription('The item name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const itemName = interaction.options.getString('itemname');
         const numberItems = interaction.options.getInteger('numbertobuy');
-
-		(async () => {
             let reply = await shop.buyItem(itemName, interaction.user.tag, numberItems, interaction.channelId)
             interaction.reply(reply);
 			// Call the addItem function from the Shop class
-		})()
 	},
 };

--- a/commands/shopCommands/edititemmenu.js
+++ b/commands/shopCommands/edititemmenu.js
@@ -11,10 +11,8 @@ module.exports = {
 			.setDescription('The item name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const itemName = interaction.options.getString('itemname');
-
-		(async () => {
 			//shop.editItemMenu returns an array with the first element being the replyEmbed and the second element being the rows
 			let reply = await shop.editItemMenu(itemName, 1, interaction.user.tag);
             if (typeof(reply) == 'string') {
@@ -24,6 +22,5 @@ module.exports = {
 				let rows = reply[1];
                 await interaction.reply({ embeds: [replyEmbed], components: [rows]});
             }
-		})()
 	},
 };

--- a/commands/shopCommands/editrecipemenu.js
+++ b/commands/shopCommands/editrecipemenu.js
@@ -11,10 +11,8 @@ module.exports = {
 			.setDescription('The recipe name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const recipeName = interaction.options.getString('recipename');
-
-		(async () => {
 			//shop.editrecipeMenu returns an array with the first element being the replyEmbed and the second element being the rows
 			let reply = await shop.editRecipeMenu(recipeName, interaction.user.tag);
             if (typeof(reply) == 'string') {
@@ -22,6 +20,5 @@ module.exports = {
             } else {
                 await interaction.reply({ embeds: [reply]});
             }
-		})()
 	},
 };

--- a/commands/shopCommands/inspect.js
+++ b/commands/shopCommands/inspect.js
@@ -10,16 +10,13 @@ module.exports = {
 			.setDescription('The item name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const itemName = interaction.options.getString('itemname');
-
-		(async () => {
             let replyEmbed = await shop.inspect(itemName);
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply({content: replyEmbed, ephemeral: true });
             } else {
                 await interaction.reply({ embeds: [replyEmbed] });
             }
-		})()
 	},
 };

--- a/commands/shopCommands/removeitem.js
+++ b/commands/shopCommands/removeitem.js
@@ -11,10 +11,8 @@ module.exports = {
 			.setDescription('The item name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const itemName = interaction.options.getString('itemname');
-
-		(async () => {
 			let returnString = await shop.removeItem(itemName);
 
 			if (returnString) {
@@ -23,6 +21,5 @@ module.exports = {
 				await interaction.reply(`Item '${itemName}' has been removed from the shop.`);
 			}
 			// Call the addItem function from the Shop class
-		})()
 	},
 };

--- a/commands/shopCommands/renamecategory.js
+++ b/commands/shopCommands/renamecategory.js
@@ -16,12 +16,10 @@ module.exports = {
             .setDescription('The new name of the category')
             .setRequired(true)
         ),
-	execute(interaction) {
+	async execute(interaction) {
         const category = interaction.options.getString('category');
         const newCategory = interaction.options.getString('newcategory');
-		(async () => {
 			reply = await shop.renameCategory(category, newCategory);
             await interaction.reply(reply);
-		})()
 	},
 };

--- a/commands/shopCommands/updateAllItemVersions.js
+++ b/commands/shopCommands/updateAllItemVersions.js
@@ -6,8 +6,7 @@ module.exports = {
 		.setName('updateallitemversions')
 		.setDescription('Update the version of all items')
 		.setDefaultMemberPermissions(0),
-	execute(interaction) {
-		(async () => {
+	async execute(interaction) {
 			try {
 				await interaction.deferReply();
 				let response = await shop.updateAllItemVersions();
@@ -17,6 +16,5 @@ module.exports = {
 				console.error('Failed to update item versions:', error);
 				await interaction.reply({ content: 'Error updating item versions.', ephemeral: true });
 			}
-		})();
 	},
 };

--- a/commands/shopCommands/updateItemVersion.js
+++ b/commands/shopCommands/updateItemVersion.js
@@ -11,13 +11,10 @@ module.exports = {
 			.setDescription('The item name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
 		const itemName = interaction.options.getString('itemname');
-
-		(async () => {
 			//shop.editItemMenu returns an array with the first element being the replyEmbed and the second element being the rows
 			let reply = await shop.updateItemVersion(itemName);
             interaction.reply(reply);
-		})()
 	},
 };


### PR DESCRIPTION
## Summary
- replace self-invoking async wrappers with `async execute` handlers across commands
- update command handlers like `map`, `editrecipemenu`, `deposit`, `buyitem` and others to use direct async/await

## Testing
- `npm test` *(fails: hangs after running two tests)*

------
https://chatgpt.com/codex/tasks/task_e_688f278e2414832eb569549dad9d5be2