### PR TITLE
fix: import REST and Routes in deploy-commands

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,10 +1,9 @@
-const { REST, Routes, SlashCommandBuilder } = require('discord.js');
+const { REST, Routes } = require('discord.js');
 // Load credentials from config.js (env vars take priority over config.json)
 const { clientId, guildId, token } = require('./config.js');
 const fs = require('node:fs');
 const path = require('node:path');
 const dbm = require('./database-manager');
-const { map } = require('./admin');
 
 
 async function loadCommands() {


### PR DESCRIPTION
## Summary
- import REST and Routes from discord.js
- remove unused admin map import

## Testing
- `npm test`
- `node deploy-commands.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688f27723fe4832e974f66bb8a92d618