### PR TITLE
refactor: export helper utilities

### DIFF
--- a/helperFile.js
+++ b/helperFile.js
@@ -162,16 +162,17 @@ async function resetIncomeCD() {
       }
     }
     
-    await dbm.saveCollection(collectionName, data);
-  }
-
-resetIncomeCD();
-
+  await dbm.saveCollection(collectionName, data);
+}
 // addTo10RecipeIngredients();
 
 module.exports = {
     addNeedNoneOfRolesToShop,
     loadResourcesJSON,
     saveResourcesJSON,
-    getResourceEmojis
-}
+    getResourceEmojis,
+    healthToLegitimacy,
+    addShireToShireNames,
+    addTo10RecipeIngredients,
+    resetIncomeCD,
+  };


### PR DESCRIPTION
## Summary
- remove automatic resetIncomeCD invocation
- export all helper utilities for explicit use

## Testing
- `npm test` *(fails: ERR_ASSERTION expected 'env-token', actual ~)*

------
https://chatgpt.com/codex/tasks/task_e_688f27790648832ead2f4d9509b8b107