### PR TITLE
chore: remove unused database manager import

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -3,7 +3,6 @@ const { REST, Routes, SlashCommandBuilder } = require('discord.js');
 const { clientId, guildId, token } = require('./config.js');
 const fs = require('node:fs');
 const path = require('node:path');
-const dbm = require('./database-manager');
 const { map } = require('./admin');
 const logger = require('./logger');
 


### PR DESCRIPTION
## Summary
- drop unused `database-manager` require in `deploy-commands.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f2fa85cc0832eb318d0ae26440573