### PR TITLE
Only log errors when level enabled

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -6,7 +6,9 @@ function shouldLog(level) {
 }
 
 module.exports = {
-  error: (...args) => console.error(...args),
+  error: (...args) => {
+    if (shouldLog('error')) console.error(...args);
+  },
   warn: (...args) => {
     if (shouldLog('warn')) console.warn(...args);
   },


### PR DESCRIPTION
## Summary
- log errors only when error level is enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f390cc7fc832ea8ab06becec5b990