### PR TITLE
refactor: export interaction handlers

### DIFF
--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -7,7 +7,7 @@ const { guildId } = require('./config.js');
 const logger = require('./logger');
 
 // MODALS
-addItem = async (interaction) => {
+const addItem = async (interaction) => {
   // Get the data entered by the user
   const itemName = interaction.fields.getTextInputValue('itemname');
   let itemIcon = interaction.fields.getTextInputValue('itemicon');
@@ -114,7 +114,7 @@ addItem = async (interaction) => {
 // // }
 // }
 
-newChar = async (interaction) => {
+const newChar = async (interaction) => {
   // Get the data entered by the user
   const userID = interaction.user.tag;
   const numericID = interaction.user.id;
@@ -159,7 +159,7 @@ newChar = async (interaction) => {
   }
 };
 
-shopLayout = async (interaction) => {
+const shopLayout = async (interaction) => {
   const categoryToEdit = interaction.fields.getTextInputValue('categorytoedit');
   const layoutString = interaction.fields.getTextInputValue('layoutstring');
 
@@ -167,33 +167,33 @@ shopLayout = async (interaction) => {
 }
 
 //BUTTONS
-shopSwitch = async (interaction) => {
+const shopSwitch = async (interaction) => {
   let [edittedEmbed, rows] = await shop.createShopEmbed(interaction.customId.slice(11), interaction);
   logger.debug(interaction);
   await interaction.update({ embeds: [edittedEmbed], components: rows});
 }
-incomeSwitch = async (interaction) => {
+const incomeSwitch = async (interaction) => {
   interaction.deferUpdate();
   let [edittedEmbed, rows] = await admin.allIncomes(interaction.customId.slice(11));
   await interaction.editReply({ embeds: [edittedEmbed], components: rows});
 }
-salesSwitch = async (interaction) => {
+const salesSwitch = async (interaction) => {
   let [edittedEmbed, rows] = await marketplace.createSalesEmbed(interaction.customId.slice(11));
   await interaction.update({ embeds: [edittedEmbed], components: rows});
 }
-allItemSwitch = async (interaction) => {
+const allItemSwitch = async (interaction) => {
   let [edittedEmbed, rows] = await shop.createAllItemsEmbed(interaction.customId.slice(11), interaction);
   await interaction.update({ embeds: [edittedEmbed], components: rows});
 }
-itemSwitch = async (interaction) => {
+const itemSwitch = async (interaction) => {
   let [edittedEmbed, rows] = await shop.editItemMenu(interaction.customId.substring(12), interaction.customId[11], interaction.user.tag);
   await interaction.update({ embeds: [edittedEmbed], components: [rows]});
 }
-balaSwitch = async (interaction) => {
+const balaSwitch = async (interaction) => {
   let [edittedEmbed, rows] = await char.balanceAll(interaction.customId[11])
   await interaction.update({ embeds: [edittedEmbed], components: rows});
 }
-helpSwitch = async (interaction) => {
+const helpSwitch = async (interaction) => {
   //This one is odder, will either have the 11th character be "A" or "R" for admin or regular help. The 12th character will be the page number.
   let isAdmin = false;
   if (interaction.customId[11] == "A") {
@@ -207,7 +207,7 @@ helpSwitch = async (interaction) => {
   await interaction.update({ embeds: [edittedEmbed], components: rows});
 }
 
-exports.handle = async (interaction) => {
+const handle = async (interaction) => {
   logger.debug(interaction.customId);
   if (interaction.isModalSubmit()) {
     if (interaction.customId === 'additemmodal') {
@@ -265,4 +265,18 @@ exports.handle = async (interaction) => {
     }
   }
 }
+
+module.exports = {
+  addItem,
+  newChar,
+  shopLayout,
+  shopSwitch,
+  incomeSwitch,
+  salesSwitch,
+  allItemSwitch,
+  itemSwitch,
+  balaSwitch,
+  helpSwitch,
+  handle,
+};
 


### PR DESCRIPTION
## Summary
- declare interaction handlers with const to avoid global leaks
- export handlers via `module.exports`

## Testing
- `npm test` *(fails: Environment variables override config.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f38e68094832eaaa6a0687d2a0468