### PR TITLE
refactor: await webhook calls and handle errors in say

### DIFF
--- a/char.js
+++ b/char.js
@@ -307,22 +307,24 @@ class char {
       let webhookAvatar = charData.icon ? charData.icon : 'https://cdn.discordapp.com/attachments/890351376004157440/1332678517888126986/NEW_LOGO_CLEAN_smallish.png?ex=6798c416&is=67977296&hm=ada5afdd0bcb677d3a0a1ca6aabe55f554810e3044048ac4e5cd85d0d73e7f0d&';
       let webhookMessage = message;
 
-      (async () => {
+      try {
         // Create a webhook
-        let webhook = await channelID.createWebhook({name: webhookName, avatar: webhookAvatar });
-        
+        let webhook = await channelID.createWebhook({ name: webhookName, avatar: webhookAvatar });
+
         // Send a message using the webhook
         await webhook.send({
-            content: webhookMessage,
-            username: webhookName,
-            avatarURL: webhookAvatar
+          content: webhookMessage,
+          username: webhookName,
+          avatarURL: webhookAvatar,
         });
 
         // Delete the webhook after sending the message
         await webhook.delete();
-      })()
 
-      return "Message sent!";
+        return "Message sent!";
+      } catch (error) {
+        throw error;
+      }
     } else {
       return "You haven't made a character! Use /newchar first";
     }


### PR DESCRIPTION
## Summary
- simplify char.say by awaiting webhook creation, message send and deletion
- surface webhook errors to callers via try/catch

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_688f39081b20832eb745aacd0b013d6b