### PR TITLE
feat: make balance responses ephemeral

### DIFF
--- a/commands/charCommands/balance.js
+++ b/commands/charCommands/balance.js
@@ -9,9 +9,9 @@ module.exports = {
 		const charID = interaction.user.tag;
             let replyEmbed = await char.balance(charID);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.reply({ content: replyEmbed, ephemeral: true });
             } else {
-                await interaction.reply({ embeds: [replyEmbed] });
+                await interaction.reply({ embeds: [replyEmbed], ephemeral: true });
             }
 	},
 };


### PR DESCRIPTION
## Summary
- make balance command replies ephemeral for both string and embed responses

## Testing
- `npm test` *(fails: Environment variables override config.json)*

------
https://chatgpt.com/codex/tasks/task_e_689283fbf538832ea2c8fd41b63da1c4