### PR TITLE
feat: add panel command and pagination

### DIFF
--- a/char.js
+++ b/char.js
@@ -56,6 +56,7 @@ class char {
         inventory: {
           "Adventure Token": 1
         },
+        ships: {},
         incomeList: {},
         incomeAvailable: true,
         stats: {
@@ -130,6 +131,19 @@ class char {
     } else {
       return "You haven't made a character! Use /newchar first";
     }
+  }
+
+  static async getShips(userID) {
+    let collectionName = 'characters';
+    let charData = await dbm.loadFile(collectionName, userID);
+    if (!charData) {
+      return {};
+    }
+    if (!charData.ships) {
+      charData.ships = {};
+      await dbm.saveFile(collectionName, userID, charData);
+    }
+    return charData.ships;
   }
 
   static async stats(userID) {

--- a/commands/charCommands/panel.js
+++ b/commands/charCommands/panel.js
@@ -1,0 +1,12 @@
+const { SlashCommandBuilder } = require('discord.js');
+const panel = require('../../panel');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('panel')
+    .setDescription('Open character panel'),
+  async execute(interaction) {
+    const [embed, rows] = await panel.mainEmbed(interaction.user.id);
+    await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
+  },
+};

--- a/commands/charCommands/storage.js
+++ b/commands/charCommands/storage.js
@@ -7,7 +7,7 @@ module.exports = {
 		.setDescription('Show your storage'),
 	async execute(interaction) {
         const userID = interaction.user.id;
-		var replyEmbed = await shop.storage(userID);
-		await interaction.reply(({ embeds: [replyEmbed] }));
-	},
+                const [replyEmbed, rows] = await shop.storage(userID, 1);
+                await interaction.reply({ embeds: [replyEmbed], components: rows });
+        },
 };

--- a/commands/shopCommands/inventory.js
+++ b/commands/shopCommands/inventory.js
@@ -7,7 +7,7 @@ module.exports = {
 		.setDescription('Show your inventory'),
 	async execute(interaction) {
         const userID = interaction.user.id;
-		var replyEmbed = await shop.createInventoryEmbed(userID);
-		await interaction.reply(({ embeds: [replyEmbed] }));
-	},
+                const [replyEmbed, rows] = await shop.createInventoryEmbed(userID, 1);
+                await interaction.reply({ embeds: [replyEmbed], components: rows });
+        },
 };

--- a/commands/shopCommands/inventoryadmin.js
+++ b/commands/shopCommands/inventoryadmin.js
@@ -13,7 +13,7 @@ module.exports = {
 		),
 	async execute(interaction) {
         const userID = interaction.options.getUser('user').id;
-		var replyEmbed = await shop.createInventoryEmbed(userID);
-		await interaction.reply(({ embeds: [replyEmbed] }));
-	},
+                const [replyEmbed, rows] = await shop.createInventoryEmbed(userID, 1);
+                await interaction.reply({ embeds: [replyEmbed], components: rows });
+        },
 };

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -2,6 +2,7 @@ const shop = require('./shop');
 const char = require('./char');
 const marketplace = require('./marketplace');
 const admin = require('./admin');
+const panel = require('./panel');
 // Import guildId from config.js (environment variables take priority)
 const { guildId } = require('./config.js');
 const logger = require('./logger');
@@ -207,6 +208,40 @@ helpSwitch = async (interaction) => {
   await interaction.update({ embeds: [edittedEmbed], components: rows});
 }
 
+panelInvSwitch = async (interaction) => {
+  const page = parseInt(interaction.customId.slice(15));
+  let [edittedEmbed, rows] = await panel.inventoryEmbed(interaction.user.id, page);
+  await interaction.update({ embeds: [edittedEmbed], components: rows, ephemeral: true });
+}
+
+panelStoreSwitch = async (interaction) => {
+  const page = parseInt(interaction.customId.slice(16));
+  let [edittedEmbed, rows] = await panel.storageEmbed(interaction.user.id, page);
+  await interaction.update({ embeds: [edittedEmbed], components: rows, ephemeral: true });
+}
+
+panelShipSwitch = async (interaction) => {
+  const page = parseInt(interaction.customId.slice(15));
+  let [edittedEmbed, rows] = await panel.shipsEmbed(interaction.user.id, page);
+  await interaction.update({ embeds: [edittedEmbed], components: rows, ephemeral: true });
+}
+
+panelSelect = async (interaction) => {
+  const choice = interaction.values[0];
+  let edittedEmbed;
+  let rows;
+  if (choice === 'inventory') {
+    [edittedEmbed, rows] = await panel.inventoryEmbed(interaction.user.id, 1);
+  } else if (choice === 'resources') {
+    [edittedEmbed, rows] = await panel.storageEmbed(interaction.user.id, 1);
+  } else if (choice === 'ships') {
+    [edittedEmbed, rows] = await panel.shipsEmbed(interaction.user.id, 1);
+  } else {
+    [edittedEmbed, rows] = await panel.mainEmbed(interaction.user.id);
+  }
+  await interaction.update({ embeds: [edittedEmbed], components: rows, ephemeral: true });
+}
+
 exports.handle = async (interaction) => {
   logger.debug(interaction.customId);
   if (interaction.isModalSubmit()) {
@@ -249,6 +284,12 @@ exports.handle = async (interaction) => {
       balaSwitch(interaction);
     } else if (interaction.customId.substring(0, 11) === 'partySelect') {
       await admin.selectParty(interaction);
+    } else if (interaction.customId.substring(0, 15) === 'panel_inv_page') {
+      panelInvSwitch(interaction);
+    } else if (interaction.customId.substring(0, 16) === 'panel_store_page') {
+      panelStoreSwitch(interaction);
+    } else if (interaction.customId.substring(0, 15) === 'panel_ship_page') {
+      panelShipSwitch(interaction);
     }
   } else if (interaction.isSelectMenu()) {
     if (interaction.customId === 'shireSelect') {
@@ -262,6 +303,9 @@ exports.handle = async (interaction) => {
     }
     if (interaction.customId === 'classSelect') {
       await admin.selectClass(interaction);
+    }
+    if (interaction.customId === 'panel_select') {
+      panelSelect(interaction);
     }
   }
 }

--- a/panel.js
+++ b/panel.js
@@ -1,0 +1,108 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder } = require('discord.js');
+const shop = require('./shop');
+const char = require('./char');
+const dbm = require('./database-manager');
+const dataGetters = require('./dataGetters');
+const clientManager = require('./clientManager');
+
+function selectRow() {
+  return new ActionRowBuilder().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId('panel_select')
+      .addOptions(
+        new StringSelectMenuOptionBuilder()
+          .setLabel('Inventory')
+          .setValue('inventory')
+          .setDescription('View your inventory'),
+        new StringSelectMenuOptionBuilder()
+          .setLabel('Resources')
+          .setValue('resources')
+          .setDescription('View stored resources'),
+        new StringSelectMenuOptionBuilder()
+          .setLabel('Ships')
+          .setValue('ships')
+          .setDescription('View your ships'),
+        new StringSelectMenuOptionBuilder()
+          .setLabel('Back')
+          .setValue('back')
+          .setDescription('Return to main panel')
+      )
+  );
+}
+
+module.exports = {
+  mainEmbed: async function (charID) {
+    charID = await dataGetters.getCharFromNumericID(charID);
+    const charData = await dbm.loadCollection('characters');
+    let balance = 0;
+    if (charData[charID]) {
+      balance = charData[charID].balance;
+    }
+    const embed = new EmbedBuilder()
+      .setColor(0x36393e)
+      .setDescription(`Classification accepted.\nBalance: ${clientManager.getEmoji('Gold')} **${balance}**\nAEGIR PANEL SYSTEM`);
+    return [embed, [selectRow()]];
+  },
+
+  inventoryEmbed: async function (charID, page = 1) {
+    let [embed, rows] = await shop.createInventoryEmbed(charID, page);
+    rows.push(selectRow());
+    return [embed, rows];
+  },
+
+  storageEmbed: async function (charID, page = 1) {
+    let [embed, rows] = await shop.storage(charID, page);
+    rows.push(selectRow());
+    return [embed, rows];
+  },
+
+  shipsEmbed: async function (charID, page = 1) {
+    charID = await dataGetters.getCharFromNumericID(charID);
+    const ships = await char.getShips(charID);
+    const shopData = await dbm.loadCollection('shop');
+    const itemsPerPage = 25;
+    const lines = [];
+    for (const [shipName, cargo] of Object.entries(ships)) {
+      lines.push(`**${shipName}**`);
+      if (cargo && Object.keys(cargo).length > 0) {
+        for (const item of Object.keys(cargo)) {
+          const icon = shopData[item]?.infoOptions.Icon || '';
+          const qty = cargo[item];
+          lines.push(`${icon} \`${item} ${qty}\``);
+        }
+      } else {
+        lines.push('`Empty`');
+      }
+    }
+    const pages = Math.max(1, Math.ceil(lines.length / itemsPerPage));
+    if (page > pages) page = pages;
+    const pageLines = lines.slice((page - 1) * itemsPerPage, page * itemsPerPage);
+    const embed = new EmbedBuilder()
+      .setTitle('Ships')
+      .setColor(0x36393e)
+      .setDescription(pageLines.length ? pageLines.join('\n') : 'No ships!');
+    if (pages > 1) {
+      embed.setFooter({ text: `Page ${page} of ${pages}` });
+    }
+    const rows = [];
+    if (pages > 1) {
+      const prevButton = new ButtonBuilder()
+        .setCustomId('panel_ship_page' + (page - 1))
+        .setLabel('<')
+        .setStyle(ButtonStyle.Secondary);
+      if (page === 1) {
+        prevButton.setDisabled(true);
+      }
+      const nextButton = new ButtonBuilder()
+        .setCustomId('panel_ship_page' + (page + 1))
+        .setLabel('>')
+        .setStyle(ButtonStyle.Secondary);
+      if (page === pages) {
+        nextButton.setDisabled(true);
+      }
+      rows.push(new ActionRowBuilder().addComponents(prevButton, nextButton));
+    }
+    rows.push(selectRow());
+    return [embed, rows];
+  },
+};


### PR DESCRIPTION
## Summary
- add `/panel` slash command with ephemeral character panel
- implement panel helpers with inventory, storage, and ships embeds
- extend inventory and storage with paginated buttons

## Testing
- `npm test` *(fails: Environment variables override config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936ef95c00832eb07eef8c16fa19b3