### PR TITLE
feat: migrate storage to postgres

### DIFF
--- a/database-manager.js
+++ b/database-manager.js
@@ -1,61 +1,84 @@
-// database-manager.js  –  SIMPLE FILE STORAGE VERSION
-const fs   = require('node:fs');
-const path = require('node:path');
+const db = require('./pg-client');
 const logger = require('./logger');
 
-const storageDir = path.join(__dirname, 'jsonStorage');
-if (!fs.existsSync(storageDir)) fs.mkdirSync(storageDir);
+const tables = ['characters', 'keys', 'shop', 'recipes', 'marketplace', 'shoplayout'];
 
-// helper to write whole collection
-function saveCollection(collectionName, data) {
-  const fp = path.join(storageDir, `${collectionName}.json`);
-  return fs.promises
-    .writeFile(fp, JSON.stringify(data, null, 2))
-    .then(() => logger.info(`Collection \"${collectionName}\" saved (file).`));
+function assertTable(name) {
+  if (!tables.includes(name)) throw new Error(`Unknown table ${name}`);
+  return name;
 }
 
-// helper to read whole collection (returns {} if missing)
-async function loadCollection(collectionName) {
-  const fp = path.join(storageDir, `${collectionName}.json`);
-  try {
-    const txt = await fs.promises.readFile(fp, 'utf8');
-    return JSON.parse(txt);
-  } catch {
-    return {};
+async function init() {
+  for (const t of tables) {
+    await db.query(`CREATE TABLE IF NOT EXISTS ${t} (id TEXT PRIMARY KEY, data JSONB)`);
   }
+  logger.debug('[database-manager] tables ensured.');
 }
-
-async function loadCollectionFileNames(collectionName) {
-  const coll = await loadCollection(collectionName);
-  return Object.keys(coll).reduce((acc, k) => ((acc[k] = k), acc), {});
-}
+init().catch(err => logger.error(err));
 
 async function saveFile(collection, doc, data) {
-  const coll = await loadCollection(collection);
-  coll[doc] = data;
-  return saveCollection(collection, coll);
+  const table = assertTable(collection);
+  await db.query(
+    `INSERT INTO ${table} (id, data) VALUES ($1, $2)
+     ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data`,
+    [doc, data]
+  );
+  logger.info(`Document "${doc}" saved in "${collection}" (db).`);
 }
 
 async function loadFile(collection, doc) {
-  const coll = await loadCollection(collection);
-  return coll[doc];
+  const table = assertTable(collection);
+  const res = await db.query(`SELECT data FROM ${table} WHERE id=$1`, [doc]);
+  return res.rows[0] ? res.rows[0].data : undefined;
+}
+
+async function saveCollection(collection, data) {
+  const table = assertTable(collection);
+  const entries = Object.entries(data);
+  await db.query('BEGIN');
+  try {
+    for (const [id, value] of entries) {
+      await db.query(
+        `INSERT INTO ${table} (id, data) VALUES ($1, $2)
+         ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data`,
+        [id, value]
+      );
+    }
+    await db.query('COMMIT');
+    logger.info(`Collection "${collection}" saved (${entries.length} docs).`);
+  } catch (err) {
+    await db.query('ROLLBACK');
+    throw err;
+  }
+}
+
+async function loadCollection(collection) {
+  const table = assertTable(collection);
+  const res = await db.query(`SELECT id, data FROM ${table}`);
+  return res.rows.reduce((acc, row) => {
+    acc[row.id] = row.data;
+    return acc;
+  }, {});
+}
+
+async function loadCollectionFileNames(collection) {
+  const table = assertTable(collection);
+  const res = await db.query(`SELECT id FROM ${table}`);
+  return res.rows.reduce((acc, row) => ((acc[row.id] = row.id), acc), {});
 }
 
 async function docDelete(collection, doc) {
-  const coll = await loadCollection(collection);
-  delete coll[doc];
-  return saveCollection(collection, coll);
+  const table = assertTable(collection);
+  await db.query(`DELETE FROM ${table} WHERE id=$1`, [doc]);
 }
 
 async function fieldDelete(collection, doc, field) {
-  const coll = await loadCollection(collection);
-  if (coll[doc]) delete coll[doc][field];
-  return saveCollection(collection, coll);
+  const table = assertTable(collection);
+  await db.query(`UPDATE ${table} SET data = data - $2 WHERE id=$1`, [doc, field]);
 }
 
 async function logData() {
-  // no‑op for the file backend
-  logger.debug('[database-manager] logData skipped (file backend).');
+  logger.debug('[database-manager] logData skipped (db backend).');
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,20 @@
 {
-  "name": "AEGIR-BOT",
+  "name": "aegir-bot",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "aegir-bot",
+      "version": "1.0.0",
+      "license": "ISC",
       "dependencies": {
         "axios": "^1.5.1",
         "discord.js": "^14.13.0",
         "firebase-admin": "^12.3.1",
         "node-fetch": "^3.3.1",
-        "openai": "^4.25.0"
+        "openai": "^4.25.0",
+        "pg": "^8.11.1"
       },
       "engines": {
         "node": "18.16.0"
@@ -1664,6 +1669,134 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
@@ -1779,6 +1912,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stream-events": {
@@ -2047,6 +2189,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "discord.js": "^14.13.0",
     "firebase-admin": "^12.3.1",
     "node-fetch": "^3.3.1",
-    "openai": "^4.25.0"
+    "openai": "^4.25.0",
+    "pg": "^8.11.1"
   }
 }

--- a/pg-client.js
+++ b/pg-client.js
@@ -1,0 +1,13 @@
+const { Pool } = require('pg');
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error('DATABASE_URL is not defined');
+}
+
+const pool = new Pool({ connectionString });
+
+module.exports = {
+  query: (text, params) => pool.query(text, params),
+  pool,
+};
+


### PR DESCRIPTION
## Summary
- add a `pg` client wired to `DATABASE_URL`
- replace file-based database manager with SQL-backed version
- ensure required tables are created at startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893dad6930c832eb125ed07fd5b7925