### PR TITLE
Refactor marketplace to SQL

### DIFF
--- a/database-manager.js
+++ b/database-manager.js
@@ -1,7 +1,7 @@
 const db = require('./pg-client');
 const logger = require('./logger');
 
-const tables = ['characters', 'keys', 'shop', 'recipes', 'marketplace', 'shoplayout', 'balances', 'inventories', 'cooldowns'];
+const tables = ['characters', 'keys', 'shop', 'recipes', 'shoplayout', 'balances', 'inventories', 'cooldowns'];
 
 function assertTable(name) {
   if (!tables.includes(name)) throw new Error(`Unknown table ${name}`);
@@ -10,10 +10,22 @@ function assertTable(name) {
 
 async function init() {
   // tables storing JSON blobs
-  const jsonTables = ['characters', 'keys', 'shop', 'recipes', 'marketplace', 'shoplayout'];
+  const jsonTables = ['characters', 'keys', 'shop', 'recipes', 'shoplayout'];
   for (const t of jsonTables) {
     await db.query(`CREATE TABLE IF NOT EXISTS ${t} (id TEXT PRIMARY KEY, data JSONB)`);
   }
+
+  await db.query(
+    `CREATE TABLE IF NOT EXISTS marketplace (
+       id       SERIAL PRIMARY KEY,
+       item     TEXT,
+       category TEXT,
+       price    INTEGER,
+       number   INTEGER,
+       seller   TEXT,
+       seller_id TEXT
+     )`
+  );
 
   // normalized tables for balances, inventories and cooldowns
   await db.query('CREATE TABLE IF NOT EXISTS balances (id TEXT PRIMARY KEY, amount INTEGER DEFAULT 0)');

--- a/marketplace.js
+++ b/marketplace.js
@@ -1,8 +1,8 @@
-const dbm = require('./database-manager'); // Importing the database manager
-const shop = require('./shop'); // Importing the database manager
-const char = require('./char'); // Importing the database manager
-const clientManager = require('./clientManager'); // Importing the database manager
+const dbm = require('./database-manager');
+const shop = require('./shop');
+const clientManager = require('./clientManager');
 const logger = require('./logger');
+const db = require('./pg-client');
 const { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } = require('discord.js');
 class marketplace {
   /**Function for a player to post a sale.
@@ -13,9 +13,7 @@ class marketplace {
    * Items will be added to the marketplace according to their item name and category- i.e. all iron swords will be next to each other, and the iron swords will be next to steel swords
    * */ 
   static async postSale(numberItems, itemName, price, userTag, userID) {
-    // Load the character.json and marketplace.json file
     let charData = await dbm.loadFile('characters', userTag);
-    let marketData = await dbm.loadCollection('marketplace');
     let shopData = await dbm.loadCollection('shop');
     // Find the item name using shop.findItemName
     itemName = await shop.findItemName(itemName, shopData);
@@ -31,32 +29,17 @@ class marketplace {
     if (!charData.inventory[itemName] || charData.inventory[itemName] < numberItems) {
       return "You don't have enough of that item to sell it!";
     }
-    // Take the items from their inventory
     charData.inventory[itemName] -= numberItems;
-    // Add them to the marketplace under a created unique ID, one greater than the last. The last will be under lastID in marketplace.json
-    marketData = marketData || { idfile: {lastID: 1000}, marketplace: {} };
-    marketData.idfile = marketData.idfile || {};
-    marketData.idfile.lastID = marketData.idfile.lastID || 1000;
-    let itemID = marketData.idfile.lastID + 1;
-    marketData.idfile.lastID = itemID;
-    // Add the item to the marketplace according to its item name and category. Category can be found in shop.getItemCategory
-    let itemCategory = await shop.getItemCategory(itemName);
-    marketData.marketplace = marketData.marketplace || {};
-    marketData.marketplace[itemCategory] = marketData.marketplace[itemCategory] || {};
-    marketData.marketplace[itemCategory][itemName] = marketData.marketplace[itemCategory][itemName] || {};
-
-    marketData.marketplace[itemCategory][itemName][itemID] = {
-      "seller": userTag,
-      "price": price,
-      "number": numberItems,
-      "sellerID": userID
-    }
-    // Save the character.json file
+    const category = await shop.getItemCategory(itemName);
+    const res = await db.query(
+      'INSERT INTO marketplace (item, category, price, number, seller, seller_id) VALUES ($1,$2,$3,$4,$5,$6) RETURNING id',
+      [itemName, category, price, numberItems, userTag, userID]
+    );
+    const itemID = res.rows[0].id;
     await dbm.saveFile('characters', userTag, charData);
-    await dbm.saveCollection('marketplace', marketData);
-    // Create an embed to return on success. Will just say @user listed **numberItems :itemIcon: itemName** to the **/sales** page for <:Gold:1232097113089904710>**price**.
     let embed = new EmbedBuilder();
     embed.setDescription(`<@${userID}> listed **${numberItems} ${await shop.getItemIcon(itemName, shopData)} ${itemName}** to the **/sales** page for ${clientManager.getEmoji("Gold")}**${price}**.`);
+    embed.setFooter({ text: `Sale ID: ${itemID}` });
     return embed;
   }
 
@@ -65,275 +48,150 @@ class marketplace {
    */
   static async createSalesEmbed(page) {
     page = Number(page);
-    // Load the marketplace.json file
-    let marketData = await dbm.loadCollection('marketplace');
-    let shopData = await dbm.loadCollection('shop');
+    const shopData = await dbm.loadCollection('shop');
+    const limit = 25;
+    const offset = (page - 1) * limit;
+    const { rows } = await db.query(
+      'SELECT id, item, price, number FROM marketplace ORDER BY item, id LIMIT $1 OFFSET $2',
+      [limit, offset]
+    );
+    const countRes = await db.query('SELECT COUNT(*) FROM marketplace');
+    const totalPages = Math.max(1, Math.ceil(Number(countRes.rows[0].count) / limit));
 
-    // Max items allowed per page
-    const maxItemsPerPage = 25;
-    let currentPage = {};
-    let allPages = [];
-    let currentPageLength = 0;
-    
-    for (const category in marketData.marketplace) {
-        const categoryItems = marketData.marketplace[category];
-        for (const itemName in categoryItems) {
-            const sales = categoryItems[itemName];
-            const numberOfSales = Object.keys(sales).length;
-            let salesProcessed = 0;
-    
-            // If this item has more sales than can fit on a single page, split it
-            while (salesProcessed < numberOfSales) {
-                // Calculate how many sales can fit on the current page
-                const remainingSpaceOnPage = maxItemsPerPage - currentPageLength;
-                const salesToAdd = Math.min(remainingSpaceOnPage, numberOfSales - salesProcessed);
-                
-                // Add a portion of sales to the current page
-                const salesSlice = Object.fromEntries(
-                    Object.entries(sales).slice(salesProcessed, salesProcessed + salesToAdd)
-                );
-    
-                currentPage[itemName] = currentPage[itemName] || {};
-                Object.assign(currentPage[itemName], salesSlice);
-                currentPageLength += salesToAdd;
-                salesProcessed += salesToAdd;
-    
-                // If the current page is full, move to the next page
-                if (currentPageLength === maxItemsPerPage) {
-                    allPages.push(currentPage);
-                    currentPage = {};
-                    currentPageLength = 0;
-                }
-            }
-        }
-    }
-    
-    // Add any remaining items to the pages
-    if (currentPageLength > 0) {
-        allPages.push(currentPage);
-    }
-    
-    const totalPages = allPages.length;
-    const sales = allPages[page - 1];
-
-    //Create embed
-    let embed = new EmbedBuilder();
-    embed.setTitle(clientManager.getEmoji("Gold") + 'Sales');
+    const embed = new EmbedBuilder();
+    embed.setTitle(clientManager.getEmoji('Gold') + 'Sales');
     embed.setColor(0x36393e);
 
     let descriptionText = '';
-
-    // Create the formatted line. `ID` :icon: **`Number ItemName [ALIGNSPACES]`**`Price`**<:Gold:1232097113089904710>, with coin and price aligned to right side (alignSpaces used to separate them and ensure all the coins and prices are aligned )
-    for (const itemName in sales) {
-      const salesList = sales[itemName];
-      for (const saleID in salesList) {
-        const sale = salesList[saleID];
-        const number = sale.number;
-        const item = itemName;
-        const icon = await shop.getItemIcon(itemName, shopData);
-        const price = sale.price;
-        let alignSpaces = ' '
-        if ((20 - item.length - ("" + price + "" + number).length) > 0) {
-          alignSpaces = ' '.repeat(20 - item.length - ("" + price + "" + number).length);
-        }
-        descriptionText += `\`${saleID}\` ${icon} **\`${number} ${item}${alignSpaces}${price}\`**${clientManager.getEmoji("Gold")}\n`;
+    for (const sale of rows) {
+      const icon = await shop.getItemIcon(sale.item, shopData);
+      const number = sale.number;
+      const item = sale.item;
+      const price = sale.price;
+      let alignSpaces = ' ';
+      if (20 - item.length - ('' + price + '' + number).length > 0) {
+        alignSpaces = ' '.repeat(20 - item.length - ('' + price + '' + number).length);
       }
+      descriptionText += `\`${sale.id}\` ${icon} **\`${number} ${item}${alignSpaces}${price}\`**${clientManager.getEmoji('Gold')}\n`;
     }
-    
+
     descriptionText += '\n';
-    // Set the accumulated description
     embed.setDescription(descriptionText);
 
     if (totalPages > 1) {
-      embed.setFooter({text: `/buysale \nPage ${page} of ${totalPages}`});
+      embed.setFooter({ text: `/buysale \nPage ${page} of ${totalPages}` });
     } else {
-      embed.setFooter({text: `/buysale`});
+      embed.setFooter({ text: `/buysale` });
     }
 
-    const rows = [];
-
-    // Create a "Previous Page" button
+    const rowsButtons = [];
     const prevButton = new ButtonBuilder()
-      .setCustomId('switch_sale' + (page-1))
+      .setCustomId('switch_sale' + (page - 1))
       .setLabel('<')
       .setStyle(ButtonStyle.Secondary);
-
-    // Disable the button on the first page
-    if (page == 1) {
-      prevButton.setDisabled(true);
-    }
+    if (page === 1) prevButton.setDisabled(true);
 
     const nextButton = new ButtonBuilder()
-          .setCustomId('switch_sale' + (page+1))
-          .setLabel('>')
-          .setStyle(ButtonStyle.Secondary);
+      .setCustomId('switch_sale' + (page + 1))
+      .setLabel('>')
+      .setStyle(ButtonStyle.Secondary);
+    if (page === totalPages) nextButton.setDisabled(true);
+    rowsButtons.push(new ActionRowBuilder().addComponents(prevButton, nextButton));
 
-    // Create a "Next Page" button if not on the last page
-    if (page == totalPages) {
-      nextButton.setDisabled(true);
-    }
-    
-    rows.push(new ActionRowBuilder().addComponents(prevButton, nextButton));
-
-    return [embed, rows];
+    return [embed, rowsButtons];
   }
  
 
   //Create a one page sales embed of just the sales for one player
   static async showSales(player, page) {
-    // Load the marketplace.json file
-    let marketData = await dbm.loadCollection('marketplace');
-    let shopData = await dbm.loadCollection('shop');
-    // Create an embed to return on success. Will just say @user has listed **numberItems :itemIcon: itemName** for <:Gold:1232097113089904710>**price**.
-    let embed = new EmbedBuilder();
+    page = Number(page);
+    const shopData = await dbm.loadCollection('shop');
+    const limit = 25;
+    const offset = (page - 1) * limit;
+    const { rows } = await db.query(
+      'SELECT id, item, price, number FROM marketplace WHERE seller=$1 ORDER BY id LIMIT $2 OFFSET $3',
+      [player, limit, offset]
+    );
+    const countRes = await db.query('SELECT COUNT(*) FROM marketplace WHERE seller=$1', [player]);
+    const totalPages = Math.max(1, Math.ceil(Number(countRes.rows[0].count) / limit));
+    const embed = new EmbedBuilder();
     embed.setTitle(`${player}'s Sales`);
     embed.setColor(0x36393e);
     let descriptionText = '';
-    let n = 1;
-    for (const category in marketData.marketplace) {
-      const categoryItems = marketData.marketplace[category];
-      for (const itemName in categoryItems) {
-        const sales = categoryItems[itemName];
-        for (const saleID in sales) {
-          const sale = sales[saleID];
-          if (sale.seller == player) {
-            const number = sale.number;
-            const item = itemName;
-            const icon = await shop.getItemIcon(itemName, shopData);
-            const price = sale.price;
-            let alignSpaces = ' '
-            if ((30 - item.length - ("" + price + "" + number).length) > 0) {
-              alignSpaces = ' '.repeat(30 - item.length - ("" + price + "" + number).length);
-            }
-            descriptionText += `\`${saleID}\` ${icon} **\`${number} ${item}${alignSpaces}${price}\`**${clientManager.getEmoji("Gold")}\n`;
-            if (descriptionText.length > 3000) {
-              if (page == n) {
-                descriptionText += '\n';
-                embed.setDescription(descriptionText);
-                embed.setFooter({text: `Page ${n}`});
-                return embed;
-              } else {
-                n++;
-                descriptionText = '';
-              }
-            }
-          }
-        }
+    for (const sale of rows) {
+      const number = sale.number;
+      const item = sale.item;
+      const icon = await shop.getItemIcon(item, shopData);
+      const price = sale.price;
+      let alignSpaces = ' ';
+      if (30 - item.length - ('' + price + '' + number).length > 0) {
+        alignSpaces = ' '.repeat(30 - item.length - ('' + price + '' + number).length);
       }
+      descriptionText += `\`${sale.id}\` ${icon} **\`${number} ${item}${alignSpaces}${price}\`**${clientManager.getEmoji('Gold')}\n`;
     }
     descriptionText += '\n';
     embed.setDescription(descriptionText);
-    embed.setFooter({text: `Page ${n}`});
+    embed.setFooter({ text: `Page ${page} of ${totalPages}` });
     return embed;
   }
 
   //Buy a sale. Send the money from the buyer to the seller, and give the buyer the items. If the seller is buying their own sale, merely give them back their items, no need to check their money- this functionality will exist for accidental sales
   static async buySale(saleID, userTag, userID) {
-    // Load the character.json and marketplace.json file
-    let charData = await dbm.loadCollection('characters');
-    let marketData = await dbm.loadCollection('marketplace');
-    let shopData = await dbm.loadCollection('shop');
-    // Search through marketData for the saleID
-    const [foundCategory, foundItemName, sale] = await marketplace.getSale(saleID);
-    // If the saleID doesn't exist, return an error
+    const charData = await dbm.loadCollection('characters');
+    const shopData = await dbm.loadCollection('shop');
+    const sale = await marketplace.getSale(saleID);
     if (!sale) {
       return "That sale doesn't exist!";
     }
-    // If the buyer is the seller, merely give them back their items, no need to check their money- this functionality will exist for accidental sales
-    if (sale.sellerID == userID) {
-      // Give the buyer the items
-      if (!charData[userTag].inventory[foundItemName]) {
-        charData[userTag].inventory[foundItemName] = 0;
+    const itemName = sale.item;
+    if (sale.seller_id == userID) {
+      if (!charData[userTag].inventory[itemName]) {
+        charData[userTag].inventory[itemName] = 0;
       }
-      charData[userTag].inventory[foundItemName] += sale.number;
-      // Remove the sale from the marketplace
-      delete marketData.marketplace[foundCategory][foundItemName][saleID];
-      // Save the character.json file
+      charData[userTag].inventory[itemName] += sale.number;
+      await db.query('DELETE FROM marketplace WHERE id=$1', [saleID]);
       await dbm.saveCollection('characters', charData);
-      // Save the marketplace.json file
-      await dbm.saveCollection('marketplace', marketData);
-      // Create an embed to return on success. Will just say @user bought **numberItems :itemIcon: itemName** from @seller for <:Gold:1232097113089904710>**price**.
       let embed = new EmbedBuilder();
-      embed.setDescription(`<@${userID}> bought **${sale.number} ${await shop.getItemIcon(foundItemName, shopData)} ${foundItemName}** back from themselves. It was listed for ${clientManager.getEmoji("Gold")}**${sale.price}**.`);
+      embed.setDescription(`<@${userID}> bought **${sale.number} ${await shop.getItemIcon(itemName, shopData)} ${itemName}** back from themselves. It was listed for ${clientManager.getEmoji("Gold")}**${sale.price}**.`);
       return embed;
     }
 
-    // Check if the buyer has enough money
     if (charData[userTag].balance < sale.price) {
       return "You don't have enough money to buy that!";
     }
-    // Take the money from the buyer
     charData[userTag].balance -= sale.price;
-    // Give the money to the seller
     charData[sale.seller].balance += sale.price;
 
-    if (!charData[userTag].inventory[foundItemName]) {
-      charData[userTag].inventory[foundItemName] = 0;
+    if (!charData[userTag].inventory[itemName]) {
+      charData[userTag].inventory[itemName] = 0;
     }
 
-    // Give the buyer the items
-    charData[userTag].inventory[foundItemName] += Number(sale.number);
-    // Remove the sale from the marketplace
-    delete marketData.marketplace[foundCategory][foundItemName][saleID];
-    // Save the character.json file
+    charData[userTag].inventory[itemName] += Number(sale.number);
+    await db.query('DELETE FROM marketplace WHERE id=$1', [saleID]);
     await dbm.saveCollection('characters', charData);
-    // Save the marketplace.json file
-    await dbm.saveCollection('marketplace', marketData);
-    // Create an embed to return on success. Will just say @user bought **numberItems :itemIcon: itemName** from @seller for <:Gold:1232097113089904710>**price**.
     let embed = new EmbedBuilder();
-    embed.setDescription(`<@${userID}> bought **${sale.number} ${await shop.getItemIcon(foundItemName, shopData)} ${foundItemName}** from <@${sale.sellerID}> for ${clientManager.getEmoji("Gold")}**${sale.price}**.`);
+    embed.setDescription(`<@${userID}> bought **${sale.number} ${await shop.getItemIcon(itemName, shopData)} ${itemName}** from <@${sale.seller_id}> for ${clientManager.getEmoji("Gold")}**${sale.price}**.`);
     return embed;
   }
 
   //Inspect a sale. Will take the saleID and return an embed with the sale information
   static async inspectSale(saleID) {
     let shopData = await dbm.loadCollection('shop');
-    // Search through marketData for the saleID
-    const [itemCategory, itemName, sale] = await marketplace.getSale(saleID);
-    // If the saleID doesn't exist, return an error
+    const sale = await marketplace.getSale(saleID);
     if (!sale) {
       return "That sale doesn't exist!";
     }
-    // Create an embed to return on success.
     let embed = new EmbedBuilder();
     embed.setTitle(`Sale ${saleID}`);
     embed.setColor(0x36393e);
-    embed.setDescription(`**${sale.number} ${await shop.getItemIcon(itemName, shopData)} ${itemName}** for ${clientManager.getEmoji("Gold")}**${sale.price}**.`);
-    embed.setFooter({text: `Seller: ${sale.seller}`});
+    embed.setDescription(`**${sale.number} ${await shop.getItemIcon(sale.item, shopData)} ${sale.item}** for ${clientManager.getEmoji("Gold")}**${sale.price}**.`);
+    embed.setFooter({ text: `Seller: ${sale.seller}` });
     return embed;
   }
 
-  //Get itemcategory, itemname and sale from saleID
   static async getSale(saleID) {
-    // Load the marketplace.json file
-    let marketData = await dbm.loadCollection('marketplace');
-    // Search through marketData for the saleID
-    let sale;
-    let itemName;
-    let itemCategory;
-    for (const category in marketData.marketplace) {
-      const categoryItems = marketData.marketplace[category];
-      for (const item in categoryItems) {
-        const sales = categoryItems[item];
-        if (sales[saleID] != undefined) {
-          sale = sales[saleID];
-          itemName = item;
-          itemCategory = category;
-          break;
-        }
-        if (sale) {
-          break;
-        }
-      }
-      if (sale) {
-        break;
-      }
-    }
-    // If the saleID doesn't exist, return an error
-    if (!sale) {
-      return "That sale doesn't exist!";
-    }
-    return [itemCategory, itemName, sale];
+    const res = await db.query('SELECT * FROM marketplace WHERE id=$1', [saleID]);
+    return res.rows[0];
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace JSON marketplace with SQL-backed listings table
- Query and paginate sales directly with SQL
- Process sale purchases with SQL deletes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893e239da68832eb2ed11c6ccd47af0