### PR TITLE
feat: support instance-based inventory

### DIFF
--- a/migrations/stack_to_instance.js
+++ b/migrations/stack_to_instance.js
@@ -1,0 +1,36 @@
+const db = require('../pg-client');
+const { randomUUID } = require('crypto');
+
+async function migrate() {
+  await db.query(`CREATE TABLE IF NOT EXISTS items (id TEXT PRIMARY KEY, data JSONB)`);
+  await db.query(`CREATE TABLE IF NOT EXISTS inventory_items (
+    instance_id TEXT PRIMARY KEY,
+    owner_id    TEXT,
+    item_id     TEXT,
+    durability  INTEGER,
+    metadata    JSONB
+  )`);
+
+  const res = await db.query('SELECT id, item, qty FROM inventories');
+  for (const row of res.rows) {
+    const defRes = await db.query('SELECT data FROM items WHERE id=$1', [row.item]);
+    const def = defRes.rows[0] ? defRes.rows[0].data : { stackable: true };
+    if (def.stackable === false) {
+      for (let i = 0; i < Number(row.qty); i++) {
+        const instanceId = randomUUID();
+        await db.query(
+          `INSERT INTO inventory_items (instance_id, owner_id, item_id, durability, metadata)
+           VALUES ($1,$2,$3,$4,$5)`,
+          [instanceId, row.id, row.item, def.durability || null, {}]
+        );
+      }
+      await db.query('DELETE FROM inventories WHERE id=$1 AND item=$2', [row.id, row.item]);
+    }
+  }
+  console.log('Migration complete');
+}
+
+migrate().then(() => db.end()).catch(err => {
+  console.error(err);
+  db.end();
+});


### PR DESCRIPTION
## Summary
- add items and inventory_items tables with helper methods
- expose inventory abstraction in `char.js`
- provide migration script to convert stacked items to instances

## Testing
- `npm test` *(fails: process hangs after initialization)*

------
https://chatgpt.com/codex/tasks/task_e_6894bd3280bc832ea38c084a853e6c9d