### PR TITLE
Remove config guildId dependency from interaction handler

### DIFF
--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -3,8 +3,6 @@ const char = require('./char');
 const marketplace = require('./marketplace');
 const admin = require('./admin');
 const panel = require('./panel');
-// Import guildId from config.js (environment variables take priority)
-const { guildId } = require('./config.js');
 const logger = require('./logger');
 
 // MODALS


### PR DESCRIPTION
## Summary
- remove guildId config import from `interaction-handler`
- make handler load without `config.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c4cfb93c832e9cb0065c6598b491