### PR TITLE
Add config validation and await interaction handler

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -38,6 +38,15 @@ if (!token || !clientId || !guildId) {
     );
   }
 }
+
+if (!token || !clientId || !guildId) {
+  const missing = [
+    !token && 'DISCORD_TOKEN',
+    !clientId && 'CLIENT_ID',
+    !guildId && 'GUILD_ID',
+  ].filter(Boolean).join(', ');
+  throw new Error(`Missing required environment variables: ${missing}`);
+}
 // ────────────────────────────────────────────────────────────────
 
 // other module imports
@@ -95,7 +104,7 @@ client.on(Events.InteractionCreate, async interaction => {
         : interaction.reply(reply);
     }
   } else {
-    interactionHandler.handle(interaction);
+    await interactionHandler.handle(interaction);
   }
 });
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -31,7 +31,7 @@ let pool;
     const filePath = path.join(rootDir, file);
     require.cache[filePath] = { id: filePath, filename: filePath, loaded: true, exports };
   };
-    stubModule('interaction-handler.js', { handle: () => {} });
+    stubModule('interaction-handler.js', { handle: async () => {} });
     stubModule('char.js', { newChar: () => {}, resetIncomeCD: () => {} });
     const { newDb } = require('pg-mem');
     const mem = newDb();
@@ -81,10 +81,10 @@ test('Environment variables override config.js', () => {
   if (require.cache[configPath]) delete require.cache[configPath];
 });
 
-test('Absence of config.js does not cause errors', () => {
+test('Missing config.js and env vars throws error', () => {
   global.__capturedToken = null;
-  assert.doesNotThrow(() => {
+  assert.throws(() => {
     delete require.cache[require.resolve(botPath)];
     require(botPath);
-  });
+  }, /Missing required environment variables/);
 });


### PR DESCRIPTION
## Summary
- throw error when required DISCORD_TOKEN/CLIENT_ID/GUILD_ID are missing
- await interaction handler for non-command interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894ce577c88832ea9c95f28b7407693