### PR TITLE
Add marketplace and database manager tests

### DIFF
--- a/tests/database-manager.test.js
+++ b/tests/database-manager.test.js
@@ -1,0 +1,59 @@
+const { test, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '..');
+const dbmPath = path.join(rootDir, 'database-manager.js');
+const pgClientPath = path.join(rootDir, 'pg-client.js');
+const loggerPath = path.join(rootDir, 'logger.js');
+let pool;
+
+// stub database and logger
+(function setup() {
+  const { newDb } = require('pg-mem');
+  const mem = newDb();
+  const pgMem = mem.adapters.createPg();
+  pool = new pgMem.Pool();
+  // pre-create tables used in tests
+  pool.query('CREATE TABLE balances (id TEXT PRIMARY KEY, amount INTEGER DEFAULT 0)');
+  pool.query('CREATE TABLE inventories (id TEXT, item TEXT, qty INTEGER, PRIMARY KEY (id, item))');
+
+  require.cache[pgClientPath] = {
+    id: pgClientPath,
+    filename: pgClientPath,
+    loaded: true,
+    exports: { query: (text, params) => pool.query(text, params), pool }
+  };
+
+  require.cache[loggerPath] = {
+    id: loggerPath,
+    filename: loggerPath,
+    loaded: true,
+    exports: { info() {}, debug() {}, error() {} }
+  };
+})();
+
+const dbm = require(dbmPath);
+
+after(() => {
+  delete require.cache[dbmPath];
+  delete require.cache[pgClientPath];
+  delete require.cache[loggerPath];
+  if (pool) pool.end();
+});
+
+test('setBalance and getBalance update values', async () => {
+  assert.equal(await dbm.getBalance('user1'), 0);
+  await dbm.setBalance('user1', 100);
+  assert.equal(await dbm.getBalance('user1'), 100);
+  await dbm.setBalance('user1', 150);
+  assert.equal(await dbm.getBalance('user1'), 150);
+});
+
+test('updateInventory adds and removes items', async () => {
+  await dbm.updateInventory('user1', 'Iron Sword', 2);
+  await dbm.updateInventory('user1', 'Iron Sword', -1);
+  assert.deepEqual(await dbm.getInventory('user1'), { 'Iron Sword': 1 });
+  await dbm.updateInventory('user1', 'Iron Sword', -1);
+  assert.deepEqual(await dbm.getInventory('user1'), {});
+});

--- a/tests/marketplace.test.js
+++ b/tests/marketplace.test.js
@@ -1,0 +1,97 @@
+const { test, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '..');
+const marketplacePath = path.join(rootDir, 'marketplace.js');
+const dbmPath = path.join(rootDir, 'database-manager.js');
+const shopPath = path.join(rootDir, 'shop.js');
+const clientManagerPath = path.join(rootDir, 'clientManager.js');
+const loggerPath = path.join(rootDir, 'logger.js');
+const pgClientPath = path.join(rootDir, 'pg-client.js');
+const discordPath = require.resolve('discord.js');
+
+let pool;
+let charData;
+let shopData;
+const stubbed = new Set([discordPath]);
+
+function stubModule(file, exports) {
+  const filePath = path.join(rootDir, file);
+  require.cache[filePath] = { id: filePath, filename: filePath, loaded: true, exports };
+  stubbed.add(filePath);
+}
+
+(function setup() {
+  class EmbedBuilder {
+    setDescription(d) { this.description = d; return this; }
+    setFooter(f) { this.footer = f; return this; }
+    setTitle(t) { this.title = t; return this; }
+    setColor(c) { this.color = c; return this; }
+  }
+  const discordStub = { EmbedBuilder, ButtonBuilder: class {}, ButtonStyle: { Secondary: 0 }, ActionRowBuilder: class {} };
+  require.cache[discordPath] = { id: discordPath, filename: discordPath, loaded: true, exports: discordStub };
+
+  stubModule('logger.js', { debug() {}, info() {}, error() {} });
+  stubModule('clientManager.js', { getEmoji: () => ':coin:' });
+  shopData = { 'Iron Sword': { infoOptions: { 'Transferrable (Y/N)': 'Yes' } } };
+  const shopStub = {
+    findItemName: async name => name.toLowerCase() === 'iron sword' ? 'Iron Sword' : 'ERROR',
+    getItemCategory: async () => 'Weapons',
+    getItemIcon: async () => ':sword:'
+  };
+  stubModule('shop.js', shopStub);
+
+  charData = {
+    'Seller#1234': { inventory: { 'Iron Sword': 5 }, balance: 100 },
+    'Buyer#5678': { inventory: {}, balance: 200 }
+  };
+  const dbmStub = {
+    loadFile: async (collection, doc) => charData[doc],
+    loadCollection: async collection => collection === 'shop' ? shopData : charData,
+    saveFile: async (collection, doc, data) => { charData[doc] = data; },
+    saveCollection: async (collection, data) => { if (collection === 'characters') charData = data; }
+  };
+  stubModule('database-manager.js', dbmStub);
+
+  const { newDb } = require('pg-mem');
+  const mem = newDb();
+  const pgMem = mem.adapters.createPg();
+  pool = new pgMem.Pool();
+  pool.query('CREATE TABLE marketplace (id SERIAL PRIMARY KEY, item TEXT, category TEXT, price INTEGER, number INTEGER, seller TEXT, seller_id TEXT)');
+  stubModule('pg-client.js', { query: (text, params) => pool.query(text, params), pool });
+})();
+
+const marketplace = require(marketplacePath);
+
+after(() => {
+  for (const p of stubbed) delete require.cache[p];
+  delete require.cache[marketplacePath];
+  if (pool) pool.end();
+});
+
+test('posting and buying a sale updates inventories and balances', async () => {
+  // reset data
+  charData = {
+    'Seller#1234': { inventory: { 'Iron Sword': 5 }, balance: 100 },
+    'Buyer#5678': { inventory: {}, balance: 200 }
+  };
+  await pool.query('DELETE FROM marketplace');
+
+  // post sale
+  const embed = await marketplace.postSale(2, 'iron sword', 50, 'Seller#1234', 'sellerId');
+  const { rows } = await pool.query('SELECT id FROM marketplace');
+  assert.equal(rows.length, 1);
+  const saleID = rows[0].id;
+  assert.equal(charData['Seller#1234'].inventory['Iron Sword'], 3);
+  assert.ok(embed.description.includes('listed'));
+
+  // buy sale
+  const buyEmbed = await marketplace.buySale(saleID, 'Buyer#5678', 'buyerId');
+  assert.equal(charData['Buyer#5678'].inventory['Iron Sword'], 2);
+  assert.equal(charData['Seller#1234'].balance, 150);
+  assert.equal(charData['Buyer#5678'].balance, 150);
+  const { rows: remaining } = await pool.query('SELECT * FROM marketplace');
+  assert.equal(remaining.length, 0);
+  assert.ok(buyEmbed.description.includes('bought'));
+});


### PR DESCRIPTION
## Summary
- add unit tests for database-manager balance and inventory helpers
- test marketplace sale posting and purchase flow using stubbed modules

## Testing
- `node --test tests/database-manager.test.js tests/marketplace.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6894d599afd8832ebbbe7f472d48c113