### PR TITLE
Await income switch deferUpdate and drop panel ephemeral

### DIFF
--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -172,7 +172,7 @@ const shopSwitch = async (interaction) => {
   await interaction.update({ embeds: [edittedEmbed], components: rows});
 };
 const incomeSwitch = async (interaction) => {
-  interaction.deferUpdate();
+  await interaction.deferUpdate();
   let [edittedEmbed, rows] = await admin.allIncomes(interaction.customId.slice(11));
   await interaction.editReply({ embeds: [edittedEmbed], components: rows});
 };
@@ -209,19 +209,19 @@ const helpSwitch = async (interaction) => {
 const panelInvSwitch = async (interaction) => {
   const page = parseInt(interaction.customId.slice(15));
   let [edittedEmbed, rows] = await panel.inventoryEmbed(interaction.user.id, page);
-  await interaction.update({ embeds: [edittedEmbed], components: rows, ephemeral: true });
+  await interaction.update({ embeds: [edittedEmbed], components: rows });
 };
 
 const panelStoreSwitch = async (interaction) => {
   const page = parseInt(interaction.customId.slice(16));
   let [edittedEmbed, rows] = await panel.storageEmbed(interaction.user.id, page);
-  await interaction.update({ embeds: [edittedEmbed], components: rows, ephemeral: true });
+  await interaction.update({ embeds: [edittedEmbed], components: rows });
 };
 
 const panelShipSwitch = async (interaction) => {
   const page = parseInt(interaction.customId.slice(15));
   let [edittedEmbed, rows] = await panel.shipsEmbed(interaction.user.id, page);
-  await interaction.update({ embeds: [edittedEmbed], components: rows, ephemeral: true });
+  await interaction.update({ embeds: [edittedEmbed], components: rows });
 };
 
 const panelSelect = async (interaction) => {
@@ -237,7 +237,7 @@ const panelSelect = async (interaction) => {
   } else {
     [edittedEmbed, rows] = await panel.mainEmbed(interaction.user.id);
   }
-  await interaction.update({ embeds: [edittedEmbed], components: rows, ephemeral: true });
+  await interaction.update({ embeds: [edittedEmbed], components: rows });
 };
 
 const handleInteractionError = async (interaction, error) => {

--- a/tests/panel-interactions.test.js
+++ b/tests/panel-interactions.test.js
@@ -114,7 +114,7 @@ function panelSelectTest(choice, expectedFn) {
       ships: ['shipRow'],
       main: ['mainRow']
     }[expectedFn];
-    assert.deepEqual(interaction.updated, { embeds: [expectedEmbed], components: expectedRow, ephemeral: true });
+    assert.deepEqual(interaction.updated, { embeds: [expectedEmbed], components: expectedRow });
   };
 }
 
@@ -147,7 +147,7 @@ function paginationTest(customId, expectedFn, expectedPage) {
       storage: ['storeRow'],
       ships: ['shipRow']
     }[expectedFn];
-    assert.deepEqual(interaction.updated, { embeds: [expectedEmbed], components: expectedRow, ephemeral: true });
+    assert.deepEqual(interaction.updated, { embeds: [expectedEmbed], components: expectedRow });
   };
 }
 


### PR DESCRIPTION
## Summary
- await `interaction.deferUpdate()` in `incomeSwitch` for proper asynchronous handling
- remove `ephemeral: true` from panel interaction updates to send responses publicly
- adjust panel interaction tests for non-ephemeral responses

## Testing
- `node --test tests/panel-interactions.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6894e3c1c880832eb3127ee183df7986