### PR TITLE
Await midnight maintenance

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -141,9 +141,9 @@ function botMidnightLoop() {
     now.getUTCSeconds()  *     1_000 -
     now.getUTCMilliseconds();
 
-  setTimeout(() => {
-    char.resetIncomeCD();
-    dbm.logData();
+  setTimeout(async () => {
+    await char.resetIncomeCD();
+    await dbm.logData();
     botMidnightLoop();
   }, msToMidnight);
 }


### PR DESCRIPTION
## Summary
- make botMidnightLoop's setTimeout callback async
- await income reset and data log before rescheduling

## Testing
- `node --test tests/database-manager.test.js`
- `node --test tests/marketplace.test.js`
- `node --test tests/panel-interactions.test.js`
- `node --test tests/config.test.js` *(terminated after ~15s due to pending timer)*

------
https://chatgpt.com/codex/tasks/task_e_68953ac76810832eacabecd9f99a847b