### PR TITLE
Handle interaction errors after reply or defer

### DIFF
--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -242,8 +242,16 @@ const panelSelect = async (interaction) => {
 
 const handleInteractionError = async (interaction, error) => {
   logger.error(error);
-  if (!interaction.deferred && !interaction.replied) {
-    await interaction.reply({ content: 'An error occurred while processing this interaction.', ephemeral: true });
+  try {
+    if (interaction.replied) {
+      await interaction.followUp({ content: 'An error occurred while processing this interaction.', ephemeral: true });
+    } else if (interaction.deferred) {
+      await interaction.editReply({ content: 'An error occurred while processing this interaction.' });
+    } else {
+      await interaction.reply({ content: 'An error occurred while processing this interaction.', ephemeral: true });
+    }
+  } catch (followUpError) {
+    logger.error(followUpError);
   }
 };
 


### PR DESCRIPTION
## Summary
- Handle interaction errors with `followUp` or `editReply` depending on interaction state
- Wrap error responses in try/catch to avoid secondary failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895508a1708832e92a678e55275fcc7