### PR TITLE
Handle missing characters in panel embeds

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -41,10 +41,13 @@ module.exports = {
   mainEmbed: async function (charID) {
     charID = await dataGetters.getCharFromNumericID(charID);
     const charData = await dbm.loadCollection('characters');
-    let balance = 0;
-    if (charData[charID]) {
-      balance = charData[charID].balance;
+    if (charID === 'ERROR' || !charData[charID]) {
+      const embed = new EmbedBuilder()
+        .setColor(0x36393e)
+        .setDescription('Character not found.');
+      return [embed, []];
     }
+    const balance = charData[charID].balance || 0;
     const embed = new EmbedBuilder()
       .setColor(0x36393e)
       .setDescription(`Classification accepted.\nBalance: ${clientManager.getEmoji('Gold')} **${balance}**\nAEGIR PANEL SYSTEM`);
@@ -65,6 +68,13 @@ module.exports = {
 
   shipsEmbed: async function (charID, page = 1) {
     charID = await dataGetters.getCharFromNumericID(charID);
+    const charData = await dbm.loadCollection('characters');
+    if (charID === 'ERROR' || !charData[charID]) {
+      const embed = new EmbedBuilder()
+        .setColor(0x36393e)
+        .setDescription('Character not found.');
+      return [embed, []];
+    }
     const ships = await char.getShips(charID);
     const shopData = await dbm.loadCollection('shop');
     const itemsPerPage = 25;

--- a/tests/panel-errors.test.js
+++ b/tests/panel-errors.test.js
@@ -1,0 +1,63 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const panelPath = path.join(__dirname, '..', 'panel.js');
+
+function discordStub() {
+  return {
+    ActionRowBuilder: class { addComponents() { return this; } },
+    ButtonBuilder: class { setCustomId() { return this; } setLabel() { return this; } setStyle() { return this; } setDisabled() { return this; } },
+    ButtonStyle: { Secondary: 1 },
+    EmbedBuilder: class {
+      constructor() { this.description = null; this.color = null; this.title = null; this.footer = null; }
+      setColor(c) { this.color = c; return this; }
+      setDescription(d) { this.description = d; return this; }
+      setTitle(t) { this.title = t; return this; }
+      setFooter(f) { this.footer = f; return this; }
+    },
+    StringSelectMenuBuilder: class { setCustomId() { return this; } addOptions() { return this; } },
+    StringSelectMenuOptionBuilder: class { setLabel() { return this; } setValue() { return this; } setDescription() { return this; } },
+  };
+}
+
+test('mainEmbed returns error when character lookup fails', async (t) => {
+  const panel = await t.mock.import(panelPath, {
+    './dataGetters': { getCharFromNumericID: async () => 'ERROR' },
+    './database-manager': { loadCollection: async () => ({}) },
+    './clientManager': { getEmoji: () => ':coin:' },
+    './shop': {},
+    './char': {},
+    'discord.js': discordStub(),
+  });
+  const [embed, rows] = await panel.mainEmbed('123');
+  assert.equal(embed.description, 'Character not found.');
+  assert.deepEqual(rows, []);
+});
+
+test('mainEmbed returns error when character data missing', async (t) => {
+  const panel = await t.mock.import(panelPath, {
+    './dataGetters': { getCharFromNumericID: async () => 'user1' },
+    './database-manager': { loadCollection: async () => ({}) },
+    './clientManager': { getEmoji: () => ':coin:' },
+    './shop': {},
+    './char': {},
+    'discord.js': discordStub(),
+  });
+  const [embed, rows] = await panel.mainEmbed('123');
+  assert.equal(embed.description, 'Character not found.');
+  assert.deepEqual(rows, []);
+});
+
+test('shipsEmbed returns error when character lookup fails', async (t) => {
+  const panel = await t.mock.import(panelPath, {
+    './dataGetters': { getCharFromNumericID: async () => 'ERROR' },
+    './database-manager': { loadCollection: async () => ({}) },
+    './clientManager': { getEmoji: () => ':coin:' },
+    './shop': {},
+    './char': { getShips: async () => ({}) },
+    'discord.js': discordStub(),
+  });
+  const [embed, rows] = await panel.shipsEmbed('123', 1);
+  assert.equal(embed.description, 'Character not found.');
+  assert.deepEqual(rows, []);
+});


### PR DESCRIPTION
## Summary
- return an informative embed when a character lookup fails
- test panel embeds for missing character cases

## Testing
- `npm test` *(fails: process hangs after DB initialization)*
- `node --test tests/panel-errors.test.js`
- `node --test tests/dataGetters.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6895d17f3bf8832eb7cf40f30460a705