### PR TITLE
Use db manager for panel balance

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -47,7 +47,7 @@ module.exports = {
         .setDescription('Character not found.');
       return [embed, []];
     }
-    const balance = charData[charID].balance || 0;
+    const balance = await dbm.getBalance(charID);
     const embed = new EmbedBuilder()
       .setColor(0x36393e)
       .setDescription(`Classification accepted.\nBalance: ${clientManager.getEmoji('Gold')} **${balance}**\nAEGIR PANEL SYSTEM`);


### PR DESCRIPTION
## Summary
- pull balance from database via `dbm.getBalance`

## Testing
- `npm test` *(fails: t.mock.import is not a function)*
- `node --test tests/panel-errors.test.js` *(fails: t.mock.import is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68971e3e2fc4832ea169556468bb070a