### PR TITLE
Allow administrators to use additemstoplayer command

### DIFF
--- a/commands/charCommands/additemstoplayer.js
+++ b/commands/charCommands/additemstoplayer.js
@@ -1,13 +1,13 @@
 //Admin command
 
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('additemstoplayer')
         .setDescription('Adds items to a player')
-        .setDefaultMemberPermissions(0)
+        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
         .addUserOption(option => option.setName('player').setDescription('The player to add items to').setRequired(true))
         .addStringOption(option => option.setName('item').setDescription('The item to add').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to add').setRequired(true)),


### PR DESCRIPTION
## Summary
- grant the additemstoplayer slash command administrator-only default permissions
- import PermissionFlagsBits from discord.js

## Testing
- `npm test` *(fails: hangs after database initialization)*
- `npm run deploy` *(fails: DATABASE_URL is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689739251824832ea9c0ce14b83c600f