### PR TITLE
feat: add optional warship stats

### DIFF
--- a/commands/shopCommands/additem.js
+++ b/commands/shopCommands/additem.js
@@ -10,34 +10,39 @@ module.exports = {
 		.addStringOption(option => option.setName('itemname').setDescription('The name of the item').setRequired(true))
 		.addStringOption(option => option.setName('itemicon').setDescription('The icon of the item').setRequired(true))
 		.addStringOption(option => option.setName('itemdescription').setDescription('The description of the item').setRequired(true))
-		.addStringOption(option => option.setName('itemcategory').setDescription('The category of the item').setRequired(true))
-		.addStringOption(option => option.setName('itemprice').setDescription('The price of the item').setRequired(false)),
-	async execute(interaction) {
-		// Call the addItem function from the Shop class with the collected information
-		if (parseInt(interaction.options.getString('itemprice'))) {
-			shop.addItem(
-				interaction.options.getString('itemname'), 
-				{ 
-					Icon: interaction.options.getString('itemicon'), 
-					Price: parseInt(interaction.options.getString('itemprice')), 
-					Description: interaction.options.getString('itemdescription'), 
-					Category: interaction.options.getString('itemcategory'),
-					"Transferrable (Y/N)": "Yes"
-				}
-			);
-		} else {
-			shop.addItem(
-				interaction.options.getString('itemname'), 
-				{ 
-					Icon: interaction.options.getString('itemicon'), 
-					Description: interaction.options.getString('itemdescription'), 
-					Category: interaction.options.getString('itemcategory'),
-					"Transferrable (Y/N)": "Yes"
-				}
-			);
-		}
+                .addStringOption(option => option.setName('itemcategory').setDescription('The category of the item').setRequired(true))
+                .addStringOption(option => option.setName('itemprice').setDescription('The price of the item').setRequired(false))
+                .addIntegerOption(option => option.setName('attack').setDescription('Attack (Warships only)').setRequired(false))
+                .addIntegerOption(option => option.setName('defence').setDescription('Defence (Warships only)').setRequired(false))
+                .addIntegerOption(option => option.setName('speed').setDescription('Speed (Warships only)').setRequired(false))
+                .addIntegerOption(option => option.setName('hp').setDescription('HP (Warships only)').setRequired(false)),
+        async execute(interaction) {
+                // Gather common item data
+                const itemName = interaction.options.getString('itemname');
+                const itemData = {
+                        Icon: interaction.options.getString('itemicon'),
+                        Description: interaction.options.getString('itemdescription'),
+                        Category: interaction.options.getString('itemcategory'),
+                        "Transferrable (Y/N)": "Yes"
+                };
 
-		// Show the modal to the user
-		await interaction.reply(`Item '${interaction.options.getString('itemname')}' has been added to the item list. Edit it using /edititemmenu. Give it a price to add to shop.`);
-	},
+                const price = parseInt(interaction.options.getString('itemprice'));
+                if (price) {
+                        itemData.Price = price;
+                }
+
+                // Include warship stats when applicable
+                if (itemData.Category && itemData.Category.toLowerCase() === 'warships') {
+                        itemData.Attack = interaction.options.getInteger('attack');
+                        itemData.Defence = interaction.options.getInteger('defence');
+                        itemData.Speed = interaction.options.getInteger('speed');
+                        itemData.HP = interaction.options.getInteger('hp');
+                }
+
+                // Call the addItem function from the Shop class with the collected information
+                shop.addItem(itemName, itemData);
+
+                // Show the modal to the user
+                await interaction.reply(`Item '${itemName}' has been added to the item list. Edit it using /edititemmenu. Give it a price to add to shop.`);
+        },
 };

--- a/commands/shopCommands/additemmodal.js
+++ b/commands/shopCommands/additemmodal.js
@@ -35,20 +35,48 @@ module.exports = {
 			.setLabel('Item Description')
 			.setStyle(TextInputStyle.Paragraph);
 
-		const itemCategoryInput = new TextInputBuilder()
-			.setCustomId('itemcategory')
-			.setLabel('Item Category')
-			.setStyle(TextInputStyle.Short);
+                const itemCategoryInput = new TextInputBuilder()
+                        .setCustomId('itemcategory')
+                        .setLabel('Item Category')
+                        .setStyle(TextInputStyle.Short);
+
+                const attackInput = new TextInputBuilder()
+                        .setCustomId('attack')
+                        .setLabel('Attack (Warships only)')
+                        .setRequired(false)
+                        .setStyle(TextInputStyle.Short);
+
+                const defenceInput = new TextInputBuilder()
+                        .setCustomId('defence')
+                        .setLabel('Defence (Warships only)')
+                        .setRequired(false)
+                        .setStyle(TextInputStyle.Short);
+
+                const speedInput = new TextInputBuilder()
+                        .setCustomId('speed')
+                        .setLabel('Speed (Warships only)')
+                        .setRequired(false)
+                        .setStyle(TextInputStyle.Short);
+
+                const hpInput = new TextInputBuilder()
+                        .setCustomId('hp')
+                        .setLabel('HP (Warships only)')
+                        .setRequired(false)
+                        .setStyle(TextInputStyle.Short);
 
 		// Create action rows for each input
-		const nameActionRow = new ActionRowBuilder().addComponents(itemNameInput);
-		const iconActionRow = new ActionRowBuilder().addComponents(itemIconInput);
-		const priceActionRow = new ActionRowBuilder().addComponents(itemPriceInput);
-		const descriptionActionRow = new ActionRowBuilder().addComponents(itemDescriptionInput);
-		const categoryActionRow = new ActionRowBuilder().addComponents(itemCategoryInput);
+                const nameActionRow = new ActionRowBuilder().addComponents(itemNameInput);
+                const iconActionRow = new ActionRowBuilder().addComponents(itemIconInput);
+                const priceActionRow = new ActionRowBuilder().addComponents(itemPriceInput);
+                const descriptionActionRow = new ActionRowBuilder().addComponents(itemDescriptionInput);
+                const categoryActionRow = new ActionRowBuilder().addComponents(itemCategoryInput);
+                const attackActionRow = new ActionRowBuilder().addComponents(attackInput);
+                const defenceActionRow = new ActionRowBuilder().addComponents(defenceInput);
+                const speedActionRow = new ActionRowBuilder().addComponents(speedInput);
+                const hpActionRow = new ActionRowBuilder().addComponents(hpInput);
 
 		// Add the action rows to the modal
-		modal.addComponents(nameActionRow, iconActionRow, priceActionRow, descriptionActionRow, categoryActionRow);
+                modal.addComponents(nameActionRow, iconActionRow, priceActionRow, descriptionActionRow, categoryActionRow, attackActionRow, defenceActionRow, speedActionRow, hpActionRow);
 
 		// Show the modal to the user
 		await interaction.showModal(modal);

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -13,6 +13,10 @@ const addItem = async (interaction) => {
   const itemPrice = interaction.fields.getTextInputValue('itemprice') || undefined;
   const itemDescription = interaction.fields.getTextInputValue('itemdescription');
   const itemCategory = interaction.fields.getTextInputValue('itemcategory');
+  const attack = interaction.fields.getTextInputValue('attack');
+  const defence = interaction.fields.getTextInputValue('defence');
+  const speed = interaction.fields.getTextInputValue('speed');
+  const hp = interaction.fields.getTextInputValue('hp');
   
   let colonCounter = 0;
   for (let i = 0; i < itemIcon.length; i++) {
@@ -27,7 +31,14 @@ const addItem = async (interaction) => {
 
   // Call the addItem function from the Shop class with the collected information
   if (itemName && parseInt(itemPrice)) {
-    await shop.addItem(itemName, { Icon: itemIcon, Price: parseInt(itemPrice), Description: itemDescription, Category: itemCategory });
+    const itemData = { Icon: itemIcon, Price: parseInt(itemPrice), Description: itemDescription, Category: itemCategory };
+    if (itemCategory && itemCategory.toLowerCase() === 'warships') {
+      itemData.Attack = attack ? parseInt(attack) : undefined;
+      itemData.Defence = defence ? parseInt(defence) : undefined;
+      itemData.Speed = speed ? parseInt(speed) : undefined;
+      itemData.HP = hp ? parseInt(hp) : undefined;
+    }
+    await shop.addItem(itemName, itemData);
     await interaction.reply(`Item '${itemName}' has been added to the item list. Use /shoplayout or ping Alex to add to shop.`);
   } else {
     // Handle missing information

--- a/shop.js
+++ b/shop.js
@@ -8,7 +8,7 @@ const logger = require('./logger');
 
 class shop {
   //Declare constants for class 
-  static infoOptions = ['Name', 'Icon', 'Category', 'Image', 'Description', 'Transferrable (Y/N)'];
+  static infoOptions = ['Name', 'Icon', 'Category', 'Image', 'Description', 'Transferrable (Y/N)', 'Attack', 'Defence', 'Speed', 'HP'];
   static shopOptions = ['Price (#)', 'Need Role', 'Give Role', 'Take Role', 'Quantity (#)', 'Channels'];
   static usageOptions = [
       'Is Usable (Y/N)', 'Removed on Use (Y/N)', 'Can Use Multiple (Y/N)', 'Need Any Of Roles', 'Need All Of Roles', 'Need None Of Roles', 'Give Role', 'Take Role',


### PR DESCRIPTION
## Summary
- allow `/additem` to specify optional Attack, Defence, Speed and HP fields
- persist warship stat fields in shop metadata
- support entering warship stats via modal and interaction handler

## Testing
- `npm test` *(hangs after database seeding)*

------
https://chatgpt.com/codex/tasks/task_e_68974f717c3c832e8be652bffc788a0e