### PR TITLE
Convert /additem to modal-based workflow

### DIFF
--- a/commands/shopCommands/additem.js
+++ b/commands/shopCommands/additem.js
@@ -1,48 +1,84 @@
 //ADMIN COMMAND
 const { SlashCommandBuilder, ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
-const shop = require('../../shop'); // Importing shop
 
 module.exports = {
-	data: new SlashCommandBuilder()
-		.setName('additem')
-		.setDescription('Add item to shop')
-		.setDefaultMemberPermissions(0)
-		.addStringOption(option => option.setName('itemname').setDescription('The name of the item').setRequired(true))
-		.addStringOption(option => option.setName('itemicon').setDescription('The icon of the item').setRequired(true))
-		.addStringOption(option => option.setName('itemdescription').setDescription('The description of the item').setRequired(true))
-                .addStringOption(option => option.setName('itemcategory').setDescription('The category of the item').setRequired(true))
-                .addStringOption(option => option.setName('itemprice').setDescription('The price of the item').setRequired(false))
-                .addIntegerOption(option => option.setName('attack').setDescription('Attack (Warships only)').setRequired(false))
-                .addIntegerOption(option => option.setName('defence').setDescription('Defence (Warships only)').setRequired(false))
-                .addIntegerOption(option => option.setName('speed').setDescription('Speed (Warships only)').setRequired(false))
-                .addIntegerOption(option => option.setName('hp').setDescription('HP (Warships only)').setRequired(false)),
+        data: new SlashCommandBuilder()
+                .setName('additem')
+                .setDescription('Add item to shop')
+                .setDefaultMemberPermissions(0),
         async execute(interaction) {
-                // Gather common item data
-                const itemName = interaction.options.getString('itemname');
-                const itemData = {
-                        Icon: interaction.options.getString('itemicon'),
-                        Description: interaction.options.getString('itemdescription'),
-                        Category: interaction.options.getString('itemcategory'),
-                        "Transferrable (Y/N)": "Yes"
-                };
+                // Create the modal
+                const modal = new ModalBuilder()
+                        .setCustomId('additemmodal')
+                        .setTitle('Add Item to Shop');
 
-                const price = parseInt(interaction.options.getString('itemprice'));
-                if (price) {
-                        itemData.Price = price;
-                }
+                // Create the text input components
+                const itemNameInput = new TextInputBuilder()
+                        .setCustomId('itemname')
+                        .setLabel('Item Name')
+                        .setStyle(TextInputStyle.Short);
 
-                // Include warship stats when applicable
-                if (itemData.Category && itemData.Category.toLowerCase() === 'warships') {
-                        itemData.Attack = interaction.options.getInteger('attack');
-                        itemData.Defence = interaction.options.getInteger('defence');
-                        itemData.Speed = interaction.options.getInteger('speed');
-                        itemData.HP = interaction.options.getInteger('hp');
-                }
+                const itemIconInput = new TextInputBuilder()
+                        .setCustomId('itemicon')
+                        .setLabel('Item Icon- Emoji to go before name in shop')
+                        .setStyle(TextInputStyle.Short);
 
-                // Call the addItem function from the Shop class with the collected information
-                shop.addItem(itemName, itemData);
+                const itemPriceInput = new TextInputBuilder()
+                        .setCustomId('itemprice')
+                        .setLabel('Item Price (Leave blank for none)')
+                        .setRequired(false)
+                        .setStyle(TextInputStyle.Short);
+
+                const itemDescriptionInput = new TextInputBuilder()
+                        .setCustomId('itemdescription')
+                        .setLabel('Item Description')
+                        .setStyle(TextInputStyle.Paragraph);
+
+                const itemCategoryInput = new TextInputBuilder()
+                        .setCustomId('itemcategory')
+                        .setLabel('Item Category')
+                        .setStyle(TextInputStyle.Short);
+
+                const attackInput = new TextInputBuilder()
+                        .setCustomId('attack')
+                        .setLabel('Attack (Warships only)')
+                        .setRequired(false)
+                        .setStyle(TextInputStyle.Short);
+
+                const defenceInput = new TextInputBuilder()
+                        .setCustomId('defence')
+                        .setLabel('Defence (Warships only)')
+                        .setRequired(false)
+                        .setStyle(TextInputStyle.Short);
+
+                const speedInput = new TextInputBuilder()
+                        .setCustomId('speed')
+                        .setLabel('Speed (Warships only)')
+                        .setRequired(false)
+                        .setStyle(TextInputStyle.Short);
+
+                const hpInput = new TextInputBuilder()
+                        .setCustomId('hp')
+                        .setLabel('HP (Warships only)')
+                        .setRequired(false)
+                        .setStyle(TextInputStyle.Short);
+
+                // Create action rows for each input
+                const nameActionRow = new ActionRowBuilder().addComponents(itemNameInput);
+                const iconActionRow = new ActionRowBuilder().addComponents(itemIconInput);
+                const priceActionRow = new ActionRowBuilder().addComponents(itemPriceInput);
+                const descriptionActionRow = new ActionRowBuilder().addComponents(itemDescriptionInput);
+                const categoryActionRow = new ActionRowBuilder().addComponents(itemCategoryInput);
+                const attackActionRow = new ActionRowBuilder().addComponents(attackInput);
+                const defenceActionRow = new ActionRowBuilder().addComponents(defenceInput);
+                const speedActionRow = new ActionRowBuilder().addComponents(speedInput);
+                const hpActionRow = new ActionRowBuilder().addComponents(hpInput);
+
+                // Add the action rows to the modal
+                modal.addComponents(nameActionRow, iconActionRow, priceActionRow, descriptionActionRow, categoryActionRow, attackActionRow, defenceActionRow, speedActionRow, hpActionRow);
 
                 // Show the modal to the user
-                await interaction.reply(`Item '${itemName}' has been added to the item list. Edit it using /edititemmenu. Give it a price to add to shop.`);
+                await interaction.showModal(modal);
         },
 };
+

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -10,14 +10,14 @@ const addItem = async (interaction) => {
   // Get the data entered by the user
   const itemName = interaction.fields.getTextInputValue('itemname');
   let itemIcon = interaction.fields.getTextInputValue('itemicon');
-  const itemPrice = interaction.fields.getTextInputValue('itemprice') || undefined;
+  const itemPrice = interaction.fields.getTextInputValue('itemprice');
   const itemDescription = interaction.fields.getTextInputValue('itemdescription');
   const itemCategory = interaction.fields.getTextInputValue('itemcategory');
   const attack = interaction.fields.getTextInputValue('attack');
   const defence = interaction.fields.getTextInputValue('defence');
   const speed = interaction.fields.getTextInputValue('speed');
   const hp = interaction.fields.getTextInputValue('hp');
-  
+
   let colonCounter = 0;
   for (let i = 0; i < itemIcon.length; i++) {
     if (itemIcon[i] == ":") {
@@ -29,9 +29,23 @@ const addItem = async (interaction) => {
     }
   }
 
+  const priceInt = itemPrice ? parseInt(itemPrice) : undefined;
+  if (itemPrice && isNaN(priceInt)) {
+    await interaction.reply({content: 'Item creation failed. Price must be an integer.', ephemeral: true});
+    return;
+  }
+
   // Call the addItem function from the Shop class with the collected information
-  if (itemName && parseInt(itemPrice)) {
-    const itemData = { Icon: itemIcon, Price: parseInt(itemPrice), Description: itemDescription, Category: itemCategory };
+  if (itemName) {
+    const itemData = {
+      Icon: itemIcon,
+      Description: itemDescription,
+      Category: itemCategory,
+      "Transferrable (Y/N)": "Yes",
+    };
+    if (priceInt !== undefined) {
+      itemData["Price (#)"] = priceInt;
+    }
     if (itemCategory && itemCategory.toLowerCase() === 'warships') {
       itemData.Attack = attack ? parseInt(attack) : undefined;
       itemData.Defence = defence ? parseInt(defence) : undefined;
@@ -39,10 +53,10 @@ const addItem = async (interaction) => {
       itemData.HP = hp ? parseInt(hp) : undefined;
     }
     await shop.addItem(itemName, itemData);
-    await interaction.reply(`Item '${itemName}' has been added to the item list. Use /shoplayout or ping Alex to add to shop.`);
+    await interaction.reply({content: `Item '${itemName}' has been added to the item list. Use /shoplayout or ping Alex to add to shop.`, ephemeral: true});
   } else {
     // Handle missing information
-    await interaction.reply({content: 'Item creation failed. Please provide a name and integer price.', ephemeral: true});
+    await interaction.reply({content: 'Item creation failed. Please provide a name.', ephemeral: true});
   }
 };
 // {


### PR DESCRIPTION
## Summary
- replace option-based `/additem` with modal that collects item details and warship stats
- parse modal submission in interaction handler, supporting optional price and warship stats and replying ephemerally

## Testing
- `npm test` *(fails: hangs after seeding database)*

------
https://chatgpt.com/codex/tasks/task_e_689752e2c4fc832ea1dea1ad2a8848d0