### PR TITLE
Handle ship purchases separately from inventory

### DIFF
--- a/char.js
+++ b/char.js
@@ -173,6 +173,20 @@ class char {
     return charData.ships;
   }
 
+  static addShip(charData, shipName) {
+    if (!charData.ships) {
+      charData.ships = {};
+    }
+    let newName = shipName;
+    let i = 2;
+    while (charData.ships[newName]) {
+      newName = `${shipName} ${i}`;
+      i++;
+    }
+    charData.ships[newName] = {};
+    return newName;
+  }
+
   static async stats(userID) {
     let collectionName = 'characters';
     let charData;

--- a/shop.js
+++ b/shop.js
@@ -1573,10 +1573,18 @@ class shop {
     }
     charData.balance -= (price * numToBuy);
 
-    if (!charData.inventory[itemName]) {
-      charData.inventory[itemName] = 0;
+    if (itemData.infoOptions.Category === "Ships") {
+      const char = require('./char');
+      for (let i = 0; i < numToBuy; i++) {
+        char.addShip(charData, itemName);
+      }
+    } else {
+      charData.inventory = charData.inventory || {};
+      if (!charData.inventory[itemName]) {
+        charData.inventory[itemName] = 0;
+      }
+      charData.inventory[itemName] += numToBuy;
     }
-    charData.inventory[itemName] += numToBuy;
 
     returnString = "Succesfully bought " + numToBuy + " " + itemName;
 

--- a/tests/buy-ship.test.js
+++ b/tests/buy-ship.test.js
@@ -1,0 +1,59 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+const shopPath = path.join(root, 'shop.js');
+const panelPath = path.join(root, 'panel.js');
+
+test('buying a ship stores it and appears in ships panel', async (t) => {
+  let charData = { numericID: 'usernum', balance: 100, inventory: {}, ships: {} };
+  const shopData = {
+    'Longboat': {
+      infoOptions: { Category: 'Ships', Icon: ':ship:' },
+      shopOptions: { 'Price (#)': 10, Channels: '', 'Need Role': '', 'Give Role': '' }
+    }
+  };
+  const dbmShopStub = {
+    loadCollection: async (col) => col === 'shop' ? shopData : { 'player1': charData },
+    loadFile: async () => charData,
+    saveFile: async (col, id, data) => { charData = data; }
+  };
+  const shopModule = await t.mock.import(shopPath, {
+    './database-manager': dbmShopStub,
+    './clientManager': { getUser: async () => ({ roles: { cache: { some: () => false }, add: () => {} } }) },
+    './logger': { debug() {}, info() {}, error() {} },
+    './char': { addShip: (data, name) => { if (!data.ships) data.ships = {}; data.ships[name] = {}; } }
+  });
+
+  const reply = await shopModule.buyItem('Longboat', 'player1', 1, 'channel');
+  assert.equal(reply, 'Succesfully bought 1 Longboat');
+  assert.equal(charData.balance, 90);
+  assert.ok(charData.ships['Longboat']);
+  assert.strictEqual(charData.inventory['Longboat'], undefined);
+
+  const panelModule = await t.mock.import(panelPath, {
+    './dataGetters': { getCharFromNumericID: async () => 'player1' },
+    './database-manager': { loadCollection: async (col) => col === 'shop' ? shopData : { 'player1': charData } },
+    './char': { getShips: async () => charData.ships },
+    './shop': {},
+    './clientManager': { getEmoji: () => ':coin:' },
+    'discord.js': {
+      EmbedBuilder: class {
+        constructor() { this.description = null; this.title = null; this.footer = null; this.color = null; }
+        setTitle(t) { this.title = t; return this; }
+        setColor(c) { this.color = c; return this; }
+        setDescription(d) { this.description = d; return this; }
+        setFooter(f) { this.footer = f; return this; }
+      },
+      ButtonBuilder: class { setCustomId() { return this; } setLabel() { return this; } setStyle() { return this; } setDisabled() { return this; } },
+      ButtonStyle: { Secondary: 1 },
+      ActionRowBuilder: class { addComponents() { return this; } },
+      StringSelectMenuBuilder: class { setCustomId() { return this; } addOptions() { return this; } },
+      StringSelectMenuOptionBuilder: class { setLabel() { return this; } setValue() { return this; } setDescription() { return this; } }
+    }
+  });
+
+  const [embed] = await panelModule.shipsEmbed('usernum', 1);
+  assert.ok(embed.description.includes('Longboat'));
+});


### PR DESCRIPTION
## Summary
- Track ships separately by adding `char.addShip` and storing purchased ships outside regular inventory
- Update shop purchase logic to recognize ship items and populate a character's `ships` collection
- Add test covering ship purchases and panel ship display

## Testing
- `node --test tests/panel-errors.test.js` *(fails: t.mock.import is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6897b9acd75c832ea004118613c2dd0b