### PR TITLE
feat: redesign shop command output with embed and controls

### DIFF
--- a/commands/shopCommands/shop.js
+++ b/commands/shopCommands/shop.js
@@ -1,17 +1,12 @@
 const { SlashCommandBuilder } = require('discord.js');
-const shop = require('../../shop'); // Importing the database manager
+const shop = require('../../shop');
 
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('shop')
 		.setDescription('List shop items'),
-	async execute(interaction) {
-		// const itemListString = await shop.shop();
-		// console.log("DATA");
-		// console.log(itemListString);
-		// await interaction.reply(itemListString);
-		await interaction.deferReply();
-		let [embed, rows] = await shop.createShopEmbed(1, interaction);
-		await interaction.editReply({ embeds: [embed], components: rows});
-	},
+        async execute(interaction) {
+                const [embed, rows] = await shop.createShopEmbed();
+                await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
+        },
 };


### PR DESCRIPTION
## Summary
- present shop items in themed 'Galactic Bazaar' embed
- add dynamic item data and grouped categories
- show Buy/Info/Close buttons and send response ephemerally

## Testing
- `npm test` *(fails: Cannot find module 'discord.js')*

------
https://chatgpt.com/codex/tasks/task_e_6897c68ca5c8832ea56b01a4afc19db5