### PR TITLE
Refactor shop embed to use central data

### DIFF
--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -182,9 +182,9 @@ const shopLayout = async (interaction) => {
 
 //BUTTONS
 const shopSwitch = async (interaction) => {
-  let [edittedEmbed, rows] = await shop.createShopEmbed(interaction.customId.slice(11), interaction);
+  const [embed, rows] = await shop.createShopEmbed();
   logger.debug(interaction);
-  await interaction.update({ embeds: [edittedEmbed], components: rows});
+  await interaction.update({ embeds: [embed], components: rows });
 };
 const incomeSwitch = async (interaction) => {
   await interaction.deferUpdate();

--- a/shop.js
+++ b/shop.js
@@ -8,29 +8,15 @@ const logger = require('./logger');
 // Static item catalog for the Galactic Bazaar embed
 const SHOP_DATA = {
   Ships: [
-    { emoji: ':corvette_emoji:', name: 'Corvette', price: 1500, description: 'Fast attack craft.' },
-    { emoji: ':frigate_emoji:', name: 'Frigate', price: 5000, description: 'Versatile medium ship.' },
+    { emoji: '🚀', name: 'Corvette', price: 1500, description: 'Fast attack craft.' },
+    { emoji: '🛰️', name: 'Frigate', price: 5000, description: 'Versatile medium ship.' },
   ],
   Resources: [
-    { emoji: ':alloy_frame_emoji:', name: 'Alloy Frame', price: 100, description: 'Durable ship plating.' },
-    { emoji: ':quantum_core_emoji:', name: 'Quantum Core', price: 400, description: 'Powers advanced systems.' },
+    { emoji: '🔧', name: 'Alloy Frame', price: 100, description: 'Durable ship plating.' },
+    { emoji: '⚡', name: 'Quantum Core', price: 400, description: 'Powers advanced systems.' },
   ],
   Specials: [
-    { emoji: ':ancient_relic_emoji:', name: 'Ancient Relic', price: 10000, description: 'Mysterious artifact.' },
-  ],
-};
-
-const SHOP_DATA = {
-  Ships: [
-    { emoji: ':corvette_emoji:', name: 'Corvette', price: 1500, description: 'Fast attack craft.' },
-    { emoji: ':frigate_emoji:', name: 'Frigate', price: 5000, description: 'Versatile medium ship.' },
-  ],
-  Resources: [
-    { emoji: ':alloy_frame_emoji:', name: 'Alloy Frame', price: 100, description: 'Durable ship plating.' },
-    { emoji: ':quantum_core_emoji:', name: 'Quantum Core', price: 400, description: 'Powers advanced systems.' },
-  ],
-  Specials: [
-    { emoji: ':ancient_relic_emoji:', name: 'Ancient Relic', price: 10000, description: 'Mysterious artifact.' },
+    { emoji: '📿', name: 'Ancient Relic', price: 10000, description: 'Mysterious artifact.' },
   ],
 };
 


### PR DESCRIPTION
## Summary
- centralize shop item data in `SHOP_DATA`
- render shop embed from `SHOP_DATA` with section headers and buttons
- simplify interaction handler to use new embed builder

## Testing
- `npm test` *(fails: DATABASE_URL is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897d3bd56d0832ea52eb740bc3fc25d