### PR TITLE
Filter unpriced items from shop embed

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -276,10 +276,6 @@ class shop {
     const categories = {};
 
     for (const [itemName, itemData] of Object.entries(shopData)) {
-      const price = itemData.shopOptions['Price (#)'];
-      if (price === '' || price === undefined || price === null) {
-        continue;
-      }
       const category = itemData.infoOptions.Category || 'Misc';
       if (!categories[category]) {
         categories[category] = [];
@@ -287,13 +283,23 @@ class shop {
       categories[category].push({
         emoji: itemData.infoOptions.Icon || '',
         name: itemData.infoOptions.Name || itemName,
-        price: price,
+        price: itemData.shopOptions['Price (#)'],
         description: itemData.infoOptions.Description || '',
       });
     }
 
     for (const category of Object.keys(categories).sort()) {
-      const items = categories[category];
+      const items = categories[category]
+        .filter(item => {
+          if (item.price === '' || item.price === undefined || item.price === null) {
+            return false;
+          }
+          item.price = Number(item.price);
+          return !Number.isNaN(item.price);
+        });
+      if (items.length === 0) {
+        continue;
+      }
       const headerEmoji = category === 'Ships' ? '🚀' : category === 'Resources' ? '📦' : '✨';
       const maxName = Math.max(...items.map(i => i.name.length));
       const maxPrice = Math.max(...items.map(i => i.price.toString().length));

--- a/tests/shop-embed.test.js
+++ b/tests/shop-embed.test.js
@@ -1,0 +1,87 @@
+const { test } = require('node:test');
+const Module = require('module');
+
+async function mockImport(modulePath, mocks) {
+  const resolvedPath = require.resolve(modulePath);
+  const originalLoad = Module._load;
+  Module._load = function(request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(mocks, request)) {
+      return mocks[request];
+    }
+    return originalLoad(request, parent, isMain);
+  };
+  delete require.cache[resolvedPath];
+  try {
+    return require(resolvedPath);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+const shopPath = path.join(root, 'shop.js');
+
+test('createShopEmbed shows only items with numeric prices', async () => {
+  const shopData = {
+    'Longboat': {
+      infoOptions: { Category: 'Ships', Icon: ':ship:', Name: 'Longboat', Description: 'A boat' },
+      shopOptions: { 'Price (#)': 100 }
+    },
+    'Broken Ship': {
+      infoOptions: { Category: 'Ships', Icon: ':ship:', Name: 'Broken Ship' },
+      shopOptions: { 'Price (#)': 'abc' }
+    },
+    'Wood': {
+      infoOptions: { Category: 'Resources', Icon: ':wood:', Name: 'Wood', Description: 'Some wood' },
+      shopOptions: { 'Price (#)': 5 }
+    },
+    'Stone': {
+      infoOptions: { Category: 'Materials', Icon: ':rock:', Name: 'Stone' },
+      shopOptions: { 'Price (#)': '' }
+    }
+  };
+
+  const dbmStub = { loadCollection: async () => shopData };
+
+  const discordStub = {
+    EmbedBuilder: class {
+      constructor() { this.fields = []; }
+      setTitle() { return this; }
+      setColor() { return this; }
+      addFields(field) { this.fields.push(field); return this; }
+    },
+    ActionRowBuilder: class { addComponents() { return this; } },
+    ButtonBuilder: class {
+      setCustomId() { return this; }
+      setLabel() { return this; }
+      setStyle() { return this; }
+    },
+    ButtonStyle: { Primary: 1 }
+  };
+
+  const shopModule = await mockImport(shopPath, {
+    './database-manager': dbmStub,
+    'discord.js': discordStub,
+    './pg-client': {},
+    './clientManager': {},
+    './dataGetters': {},
+    './logger': { debug() {}, info() {}, error() {} }
+  });
+
+  const [embed] = await shopModule.createShopEmbed();
+  const categories = embed.fields.map(f => f.name);
+  assert.equal(categories.length, 2);
+  assert.ok(categories.some(name => name.includes('Ships')));
+  assert.ok(categories.some(name => name.includes('Resources')));
+
+  const shipsField = embed.fields.find(f => f.name.includes('Ships'));
+  assert.ok(shipsField.value.includes('Longboat'));
+  assert.ok(!shipsField.value.includes('Broken Ship'));
+
+  const resourcesField = embed.fields.find(f => f.name.includes('Resources'));
+  assert.ok(resourcesField.value.includes('Wood'));
+  assert.ok(!resourcesField.value.includes('Stone'));
+});


### PR DESCRIPTION
## Summary
- Ensure shop embed only lists items with numeric prices
- Add unit test for createShopEmbed pricing filter

## Testing
- `node --test tests/shop-embed.test.js`
- `node --test` *(fails: DATABASE_URL is not defined in buy-ship.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68986213bae8832ea96f8f9303fce886