### PR TITLE
Remove shop buttons from embed

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -317,13 +317,14 @@ class shop {
       });
     }
 
-    const row = new ActionRowBuilder().addComponents(
-      new ButtonBuilder().setCustomId('shop_buy').setLabel('Buy').setStyle(ButtonStyle.Primary),
-      new ButtonBuilder().setCustomId('shop_info').setLabel('Info').setStyle(ButtonStyle.Primary),
-      new ButtonBuilder().setCustomId('shop_close').setLabel('Close').setStyle(ButtonStyle.Primary)
-    );
+    // Buttons removed: previously created an ActionRowBuilder with Buy, Info, Close buttons
+    // const row = new ActionRowBuilder().addComponents(
+    //   new ButtonBuilder().setCustomId('shop_buy').setLabel('Buy').setStyle(ButtonStyle.Primary),
+    //   new ButtonBuilder().setCustomId('shop_info').setLabel('Info').setStyle(ButtonStyle.Primary),
+    //   new ButtonBuilder().setCustomId('shop_close').setLabel('Close').setStyle(ButtonStyle.Primary)
+    // );
 
-    return [embed, [row]];
+    return [embed, []];
   }
 
   static async renameCategory(oldCategory, newCategory) {


### PR DESCRIPTION
## Summary
- drop buttons from shop embed
- return only embed without components

## Testing
- `npm test` *(fails: DATABASE_URL is not defined / ECONNREFUSED)*
- `DATABASE_URL=postgresql://localhost/test node --test tests/shop-embed.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6898687d1ef8832e81d8cfb2976e74ad