### PR TITLE
Add storage/ships sources for category embeds

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -68,7 +68,7 @@ module.exports = {
         .setDescription('Character not found.');
       return [embed, []];
     }
-    let [embed, rows] = await shop.createCategoryEmbed(charID, 'Resources', page, 'panel_store_page');
+    let [embed, rows] = await shop.createCategoryEmbed(charID, 'Resources', page, 'panel_store_page', 'storage');
     rows.push(selectRow());
     return [embed, rows];
   },
@@ -82,7 +82,7 @@ module.exports = {
         .setDescription('Character not found.');
       return [embed, []];
     }
-    let [embed, rows] = await shop.createCategoryEmbed(charID, 'Ships', page, 'panel_ship_page');
+    let [embed, rows] = await shop.createCategoryEmbed(charID, 'Ships', page, 'panel_ship_page', 'ships');
     rows.push(selectRow());
     return [embed, rows];
   },

--- a/tests/panel-category.test.js
+++ b/tests/panel-category.test.js
@@ -25,7 +25,13 @@ function discordStub() {
 
 test('resources and ships appear only in their submenus', async (t) => {
   const charData = {
-    player1: { inventory: { Longboat: 1, Iron: 5, Sword: 2 }, balance: 0, numericID: 'player1' }
+    player1: {
+      inventory: { Sword: 2 },
+      storage: { Iron: 5 },
+      ships: { Longboat: {} },
+      balance: 0,
+      numericID: 'player1'
+    }
   };
   const shopData = {
     Longboat: { infoOptions: { Category: 'Ships', Icon: ':ship:' } },


### PR DESCRIPTION
## Summary
- allow `createCategoryEmbed` to pull from inventory, storage, or ships
- wire panel storage/ship views to new source selector
- test ships and storage are shown only in respective views

## Testing
- `node --test --experimental-test-module-mocks tests/panel-category.test.js` *(fails: TypeError [Error]: t.mock.import is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6898768017fc832ea62ce946d2384404