### PR TITLE
Add storage/ships sources for category embeds

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -68,7 +68,7 @@ module.exports = {
         .setDescription('Character not found.');
       return [embed, []];
     }
-    let [embed, rows] = await shop.createCategoryEmbed(charID, 'Resources', page, 'panel_store_page');
+    let [embed, rows] = await shop.createCategoryEmbed(charID, 'Resources', page, 'panel_store_page', 'storage');
     rows.push(selectRow());
     return [embed, rows];
   },
@@ -82,7 +82,7 @@ module.exports = {
         .setDescription('Character not found.');
       return [embed, []];
     }
-    let [embed, rows] = await shop.createCategoryEmbed(charID, 'Ships', page, 'panel_ship_page');
+    let [embed, rows] = await shop.createCategoryEmbed(charID, 'Ships', page, 'panel_ship_page', 'ships');
     rows.push(selectRow());
     return [embed, rows];
   },

--- a/tests/panel-category.test.js
+++ b/tests/panel-category.test.js
@@ -23,9 +23,20 @@ function discordStub() {
   };
 }
 
-test('resources and ships appear only in their submenus', async (t) => {
+function mockModule(modulePath, mock) {
+  const resolved = require.resolve(modulePath);
+  require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports: mock };
+}
+
+test('resources and ships appear only in their submenus', async () => {
   const charData = {
-    player1: { inventory: { Longboat: 1, Iron: 5, Sword: 2 }, balance: 0, numericID: 'player1' }
+    player1: {
+      inventory: { Sword: 2 },
+      storage: { Iron: 5 },
+      ships: { Longboat: {} },
+      balance: 0,
+      numericID: 'player1'
+    }
   };
   const shopData = {
     Longboat: { infoOptions: { Category: 'Ships', Icon: ':ship:' } },
@@ -38,21 +49,15 @@ test('resources and ships appear only in their submenus', async (t) => {
   };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
-  const shopModule = await t.mock.import(shopPath, {
-    './database-manager': dbmStub,
-    './pg-client': { query: async () => ({ rows: [] }) },
-    './clientManager': {},
-    './dataGetters': dataGettersStub,
-    './logger': { debug() {}, info() {}, error() {} }
-  });
+  mockModule(path.join(root, 'database-manager.js'), dbmStub);
+  mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [] }) });
+  mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
+  mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
+  mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });
+  mockModule('discord.js', discordStub());
 
-  const panelModule = await t.mock.import(panelPath, {
-    './shop': shopModule,
-    './database-manager': dbmStub,
-    './dataGetters': dataGettersStub,
-    './clientManager': { getEmoji: () => ':coin:' },
-    'discord.js': discordStub(),
-  });
+  const shopModule = require(shopPath);
+  const panelModule = require(panelPath);
 
   const [invEmbed] = await panelModule.inventoryEmbed('player1', 1);
   assert.ok(invEmbed.description.includes('Sword'));
@@ -69,3 +74,4 @@ test('resources and ships appear only in their submenus', async (t) => {
   assert.ok(!shipEmbed.description.includes('Iron'));
   assert.ok(!shipEmbed.description.includes('Sword'));
 });
+


### PR DESCRIPTION
## Summary
- allow `createCategoryEmbed` to pull from inventory, storage, or ships
- wire panel storage/ship views to new source selector
- test ships and storage are shown only in respective views
- replace unsupported `t.mock.import` with manual require-cache stubbing in tests
- document `createCategoryEmbed` source options and behavior

## Testing
- `node --test tests/panel-category.test.js`
- `npm test` *(hangs: process did not exit)*

------
https://chatgpt.com/codex/tasks/task_e_6898768017fc832ea62ce946d2384404