### PR TITLE
Fix open timer in config tests

### DIFF
--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -8,6 +8,8 @@ const botPath = path.join(rootDir, 'bot.js');
 const configPath = path.join(rootDir, 'config.js');
 const discordModulePath = require.resolve('discord.js');
 let pool;
+const originalSetTimeout = global.setTimeout;
+global.setTimeout = () => ({ ref() {}, unref() {} });
 
 // ── stub discord.js and other local modules ──────────────────────
 (function setupStubs() {
@@ -50,6 +52,7 @@ fs.readdirSync = function(p, opts) {
 
 after(() => {
   fs.readdirSync = originalReaddirSync;
+  global.setTimeout = originalSetTimeout;
   if (require.cache[discordModulePath]) delete require.cache[discordModulePath];
   if (fs.existsSync(configPath)) fs.rmSync(configPath);
   if (require.cache[configPath]) delete require.cache[configPath];


### PR DESCRIPTION
## Summary
- prevent bot's midnight loop timer from running during config tests
- restore original `setTimeout` after tests to avoid leaving handles open

## Testing
- `node --test --test-name-pattern="Environment variables override config.js" tests/config.test.js`
- `node --test --test-name-pattern="setBalance and getBalance update values" tests/database-manager.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898903a0368832e8defd11b21d32d0c