### PR TITLE
Handle ship transfers separately when gifting items

### DIFF
--- a/char.js
+++ b/char.js
@@ -1739,12 +1739,31 @@ class char {
 
     if (charData && charData2) {
       if (charData.inventory[item] && charData.inventory[item] >= amount) {
+        const category = (shopData[item].infoOptions.Category || '').trim().toLowerCase();
+
         charData.inventory[item] -= amount;
-        if (charData2.inventory[item]) {
-          charData2.inventory[item] += amount;
-        } else {
-          charData2.inventory[item] = amount;
+        if (charData.inventory[item] <= 0) {
+          delete charData.inventory[item];
         }
+
+        if (category === 'ships' || category === 'ship') {
+          for (let i = 0; i < amount; i++) {
+            char.addShip(charData2, item);
+          }
+          if (charData2.inventory[item] && charData2.inventory[item] <= 0) {
+            delete charData2.inventory[item];
+          }
+        } else {
+          if (charData2.inventory[item]) {
+            charData2.inventory[item] += amount;
+          } else {
+            charData2.inventory[item] = amount;
+          }
+          if (charData2.inventory[item] <= 0) {
+            delete charData2.inventory[item];
+          }
+        }
+
         await dbm.saveFile(collectionName, playerGiving, charData);
         await dbm.saveFile(collectionName, player, charData2);
         return true;

--- a/tests/give-ship.test.js
+++ b/tests/give-ship.test.js
@@ -1,0 +1,82 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('module');
+const path = require('node:path');
+
+// helper to mock imports similar to other tests
+async function mockImport(modulePath, mocks) {
+  const resolvedPath = require.resolve(modulePath);
+  const originalLoad = Module._load;
+  const resolvedMocks = {};
+  for (const [key, value] of Object.entries(mocks)) {
+    try {
+      const abs = require.resolve(key, { paths: [path.dirname(resolvedPath)] });
+      resolvedMocks[abs] = value;
+      delete require.cache[abs];
+    } catch {}
+  }
+  Module._load = function(request, parent, isMain) {
+    const resolved = Module._resolveFilename(request, parent, isMain);
+    if (Object.prototype.hasOwnProperty.call(resolvedMocks, resolved)) {
+      return resolvedMocks[resolved];
+    }
+    return originalLoad(resolved, parent, isMain);
+  };
+  delete require.cache[resolvedPath];
+  try {
+    return require(resolvedPath);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+const root = path.join(__dirname, '..');
+const charPath = path.join(root, 'char.js');
+
+test('transferring a ship gives it to ships collection only', async () => {
+  let giver = { inventory: { Longboat: 1 }, ships: {} };
+  let receiver = { inventory: {}, ships: {} };
+  const shopData = {
+    Longboat: { infoOptions: { Category: 'Ships', 'Transferrable (Y/N)': 'Yes' } }
+  };
+
+  const dbmStub = {
+    loadCollection: async (col) => {
+      if (col === 'shop') return shopData;
+      return { giver, receiver };
+    },
+    saveFile: async (col, id, data) => {
+      if (id === 'giver') giver = data;
+      if (id === 'receiver') receiver = data;
+    }
+  };
+
+  const shopStub = { findItemName: async (name) => name };
+
+  const charModule = await mockImport(charPath, {
+    './database-manager': dbmStub,
+    './shop': shopStub,
+    './logger': { debug() {}, info() {}, error() {} },
+    './clientManager': {},
+    './pg-client': {}
+  });
+
+  let added = 0;
+  charModule.addShip = (data, name) => {
+    added++;
+    if (!data.ships) data.ships = {};
+    data.ships[name] = {};
+  };
+  charModule.findPlayerData = async (id) => {
+    if (id === 'giver') return ['giver', giver];
+    if (id === 'receiver') return ['receiver', receiver];
+    return [false, false];
+  };
+
+  const res = await charModule.giveItemToPlayer('giver', 'receiver', 'Longboat', 1);
+  assert.equal(res, true);
+  assert.equal(added, 1);
+  assert.ok(receiver.ships['Longboat']);
+  assert.strictEqual(receiver.inventory['Longboat'], undefined);
+  assert.strictEqual(giver.inventory['Longboat'], undefined);
+});


### PR DESCRIPTION
## Summary
- Adjust `/giveitem` logic to treat ships as special category, adding them via `addShip` instead of inventory
- Clean inventories after transfer and persist both player records
- Add unit test verifying ship transfers populate the recipient's `ships` list only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68989f57c4b8832eaf4d49489c68d64d