### PR TITLE
Sync item transfers with inventory tables

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -576,22 +576,14 @@ class shop {
     charID = await dataGetters.getCharFromNumericID(charID);
     page = Number(page);
     const itemsPerPage = 25;
-    // load data from characters.json and shop.json
-    const charData = await dbm.loadCollection('characters');
+    // load data from db
     const shopData = await dbm.loadCollection('shop');
+    const inventoryStacks = await dbm.getInventory(charID);
 
-    // create a 2d of items in the player's inventory sorted by category. Remove items with 0 quantity or that don't exist in the shop
-    let deleted = false;
-    let inventory = [];
-    for (const item in charData[charID].inventory) {
-      if (charData[charID].inventory[item] == 0) {
-        deleted = true;
-        delete charData[charID].inventory[item];
-        continue;
-      }
+    // create a 2d of items in the player's inventory sorted by category
+    let inventory = {};
+    for (const item in inventoryStacks) {
       if (!shopData[item]) {
-        deleted = true;
-        delete charData[charID].inventory[item];
         continue;
       }
       const categoryRaw = shopData[item].infoOptions.Category || '';
@@ -604,9 +596,6 @@ class shop {
         inventory[category] = [];
       }
       inventory[category].push(item);
-    }
-    if (deleted) {
-      await dbm.saveCollection('characters', charData);
     }
 
     const inventoryCategories = Object.keys(inventory);
@@ -654,7 +643,7 @@ class shop {
       descriptionText += inventory[category]
         .map((item) => {
           const icon = shopData[item].infoOptions.Icon;
-          const quantity = charData[charID].inventory[item];
+          const quantity = inventoryStacks[item];
 
           let alignSpaces = ' ';
           if ((30 - item.length - ("" + quantity).length) > 0){

--- a/tests/give-ship.test.js
+++ b/tests/give-ship.test.js
@@ -48,7 +48,18 @@ test('transferring a ship gives it to ships collection only', async () => {
     saveFile: async (col, id, data) => {
       if (id === 'giver') giver = data;
       if (id === 'receiver') receiver = data;
-    }
+    },
+    getInventory: async (id) => {
+      if (id === 'giver') return giver.inventory;
+      if (id === 'receiver') return receiver.inventory;
+      return {};
+    },
+    updateInventory: async (id, item, delta) => {
+      const target = id === 'giver' ? giver : receiver;
+      target.inventory[item] = (target.inventory[item] || 0) + delta;
+      if (target.inventory[item] <= 0) delete target.inventory[item];
+    },
+    getItemDefinition: async () => ({})
   };
 
   const shopStub = { findItemName: async (name) => name };

--- a/tests/panel-category.test.js
+++ b/tests/panel-category.test.js
@@ -45,7 +45,8 @@ test('resources and ships appear only in their submenus', async () => {
   };
   const dbmStub = {
     loadCollection: async (col) => col === 'characters' ? charData : shopData,
-    saveCollection: async () => {}
+    saveCollection: async () => {},
+    getInventory: async (id) => (charData[id] ? charData[id].inventory : {})
   };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 


### PR DESCRIPTION
## Summary
- Use `char.removeItem` and `char.addItem` when giving items to sync both legacy and normalized inventories
- Refresh and persist character metadata after transfers
- Pull inventory displays from the database so changes appear immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898a53cc688832e865c707726bfee9e