### PR TITLE
Remove duplicate item category filter

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -531,23 +531,7 @@ for (const item in sourceData) {
   if (!matches(itemCat)) continue;
   items.push(item);
 }
-
-
-      const itemCat = (
-        shopInfo?.infoOptions.Category || (source === 'ships' ? 'ships' : '')
-      ).toLowerCase();
-      const matches = (cat) => {
-        if (target === 'ships') return cat === 'ships' || cat === 'ship';
-        if (target === 'resources') return cat === 'resources' || cat === 'resource';
-        return cat === target;
-      };
-      if (!matches(itemCat)) {
-        continue;
-      }
-      items.push(item);
-    }
-
-    if (deleted && (source === 'ships' || sourceIsLegacy)) {
+if (deleted && (source === 'ships' || sourceIsLegacy)) {
       if (source === 'ships') {
         charData[charID].ships = sourceData;
       } else if (source === 'storage') {


### PR DESCRIPTION
## Summary
- delete redundant category matching block from inventory processing in `shop.js`

## Testing
- `DISCORD_TOKEN=1 CLIENT_ID=1 GUILD_ID=1 npm start` *(fails: DATABASE_URL is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689a0395a104832e8bf20cb1376845f5