### PR TITLE
Use user tags for inventory identifiers

### DIFF
--- a/commands/shopCommands/inventory.js
+++ b/commands/shopCommands/inventory.js
@@ -6,7 +6,7 @@ module.exports = {
 		.setName('inventory')
 		.setDescription('Show your inventory'),
 	async execute(interaction) {
-        const userID = interaction.user.id;
+        const userID = interaction.user.tag;
                 const [replyEmbed, rows] = await shop.createInventoryEmbed(userID, 1);
                 await interaction.reply({ embeds: [replyEmbed], components: rows });
         },

--- a/commands/shopCommands/inventoryadmin.js
+++ b/commands/shopCommands/inventoryadmin.js
@@ -12,7 +12,7 @@ module.exports = {
 				.setRequired(true)
 		),
 	async execute(interaction) {
-        const userID = interaction.options.getUser('user').id;
+        const userID = interaction.options.getUser('user').tag;
                 const [replyEmbed, rows] = await shop.createInventoryEmbed(userID, 1);
                 await interaction.reply({ embeds: [replyEmbed], components: rows });
         },

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -223,7 +223,7 @@ const helpSwitch = async (interaction) => {
 
 const panelInvSwitch = async (interaction) => {
   const page = parseInt(interaction.customId.slice(15));
-  let [edittedEmbed, rows] = await panel.inventoryEmbed(interaction.user.id, page);
+  let [edittedEmbed, rows] = await panel.inventoryEmbed(interaction.user.tag, page);
   await interaction.update({ embeds: [edittedEmbed], components: rows });
 };
 
@@ -244,7 +244,7 @@ const panelSelect = async (interaction) => {
   let edittedEmbed;
   let rows;
   if (choice === 'inventory') {
-    [edittedEmbed, rows] = await panel.inventoryEmbed(interaction.user.id, 1);
+    [edittedEmbed, rows] = await panel.inventoryEmbed(interaction.user.tag, 1);
   } else if (choice === 'resources') {
     [edittedEmbed, rows] = await panel.storageEmbed(interaction.user.id, 1);
   } else if (choice === 'ships') {

--- a/shop.js
+++ b/shop.js
@@ -599,14 +599,13 @@ if (deleted && (source === 'ships' || sourceIsLegacy)) {
 
   //function to create an embed of player inventory
   static async createInventoryEmbed(charID, page = 1) {
-    charID = await dataGetters.getCharFromNumericID(charID);
     page = Number(page);
     const itemsPerPage = 25;
     // load data from db
     const shopData = await dbm.loadCollection('shop');
     const charData = await dbm.loadCollection('characters');
 
-    if (charID === 'ERROR' || !charData[charID]) {
+    if (!charData[charID]) {
       const embed = new Discord.EmbedBuilder()
         .setColor(0x36393e)
         .setDescription('Character not found.');

--- a/tests/panel-interactions.test.js
+++ b/tests/panel-interactions.test.js
@@ -100,7 +100,8 @@ function panelSelectTest(choice, expectedFn) {
     const interaction = createSelectInteraction(choice);
     await handler.handle(interaction);
     assert.equal(called.fn, expectedFn);
-    assert.equal(called.id, 'user123');
+    const expectedId = expectedFn === 'inventory' ? 'stub' : 'user123';
+    assert.equal(called.id, expectedId);
     if (called.page) assert.equal(called.page, 1);
     const expectedEmbed = {
       inventory: 'invEmbed',
@@ -136,7 +137,8 @@ function paginationTest(customId, expectedFn, expectedPage) {
     const interaction = createButtonInteraction(customId);
     await handler.handle(interaction);
     assert.equal(called.fn, expectedFn);
-    assert.deepEqual(called, { fn: expectedFn, id: 'user123', page: expectedPage });
+    const expectedId = expectedFn === 'inventory' ? 'stub' : 'user123';
+    assert.deepEqual(called, { fn: expectedFn, id: expectedId, page: expectedPage });
     const expectedEmbed = {
       inventory: 'invEmbed',
       storage: 'storeEmbed',


### PR DESCRIPTION
## Summary
- Align inventory commands to store and fetch by Discord user tag
- Adjust panel interactions and embeds to use tag-based inventory lookup
- Update tests for tag-based inventory IDs

## Testing
- `npm test`
- `/inventory` (stubbed)

------
https://chatgpt.com/codex/tasks/task_e_689a0eccde24832e8dffa0accf3dda9a