### PR TITLE
Fix inventory char lookup and legacy resource/ship handling

### DIFF
--- a/dataGetters.js
+++ b/dataGetters.js
@@ -1,17 +1,20 @@
 const dbm = require('./database-manager');
 
 class dataGetters {
-    static async getCharFromNumericID(numericID) {
-        const idStr = String(numericID);
-        const chars = await dbm.loadCollection('characters');
+  static async getCharFromNumericID(numericID) {
+    const chars = await dbm.loadCollection('characters');
 
-        // Search for numericID (or user_id if you add it later)
-        for (const [charKey, data] of Object.entries(chars)) {
-            const stored = String(data.numericID || data.user_id || '');
-            if (stored === idStr) return charKey;
-        }
-        return "ERROR";
+    // If caller already passed a character key (e.g., "serski"), accept it.
+    if (chars[numericID]) return numericID;
+
+    const idStr = String(numericID);
+    for (const [charKey, data] of Object.entries(chars)) {
+      const stored = String(data?.numericID || data?.user_id || '');
+      if (stored === idStr) return charKey;
     }
+    return 'ERROR';
+  }
 }
 
 module.exports = dataGetters;
+


### PR DESCRIPTION
## Summary
- Improve character lookup: accept character keys or numeric IDs
- Show resources in inventory and migrate legacy ship/storage data
- Normalize panel ships/resources from legacy inventory or storage

## Testing
- `npm test` *(fails: inventory-command.test.js, panel-interactions.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689a500b7d4c832ea43b76e54ef79644