### PR TITLE
Normalize legacy items in category embed

### DIFF
--- a/tests/create-category-embed.test.js
+++ b/tests/create-category-embed.test.js
@@ -1,0 +1,75 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+const shopPath = path.join(root, 'shop.js');
+
+function discordStub() {
+  return {
+    ActionRowBuilder: class { addComponents() { return this; } },
+    ButtonBuilder: class { setCustomId() { return this; } setLabel() { return this; } setStyle() { return this; } setDisabled() { return this; } },
+    ButtonStyle: { Secondary: 1 },
+    EmbedBuilder: class {
+      constructor() { this.description = null; this.title = null; this.footer = null; this.color = null; }
+      setTitle(t) { this.title = t; return this; }
+      setColor(c) { this.color = c; return this; }
+      setDescription(d) { this.description = d; return this; }
+      setFooter(f) { this.footer = f; return this; }
+    },
+    StringSelectMenuBuilder: class { setCustomId() { return this; } addOptions() { return this; } },
+    StringSelectMenuOptionBuilder: class { setLabel() { return this; } setValue() { return this; } setDescription() { return this; } },
+  };
+}
+
+function mockModule(modulePath, mock) {
+  const resolved = require.resolve(modulePath);
+  require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports: mock };
+}
+
+test('createCategoryEmbed remaps legacy item names via findItemName', async () => {
+  delete require.cache[require.resolve(shopPath)];
+
+  const charData = { 'Player#0001': { inventory: { wood: 2 }, numericID: 'player1' } };
+  const shopData = { Wood: { infoOptions: { Category: 'Resources', Icon: ':wood:' } } };
+  const dbmStub = {
+    loadCollection: async (col) => (col === 'characters' ? charData : shopData),
+    saveCollection: async () => {},
+  };
+  const dataGettersStub = { getCharFromNumericID: async (id) => id };
+
+  mockModule(path.join(root, 'database-manager.js'), dbmStub);
+  mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [{ id: 'Wood' }] }) });
+  mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
+  mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
+  mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });
+  mockModule('discord.js', discordStub());
+
+  const shopModule = require(shopPath);
+  const [embed] = await shopModule.createCategoryEmbed('Player#0001', 'Resources', 1);
+  assert.ok(embed.description.includes('Wood'));
+  assert.ok(!('wood' in charData['Player#0001'].inventory));
+});
+
+test('createCategoryEmbed categorizes unknown items as misc', async () => {
+  delete require.cache[require.resolve(shopPath)];
+
+  const charData = { 'Player#0001': { inventory: { Mystery: 1 }, numericID: 'player1' } };
+  const shopData = {};
+  const dbmStub = {
+    loadCollection: async (col) => (col === 'characters' ? charData : shopData),
+    saveCollection: async () => {},
+  };
+  const dataGettersStub = { getCharFromNumericID: async (id) => id };
+
+  mockModule(path.join(root, 'database-manager.js'), dbmStub);
+  mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [] }) });
+  mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
+  mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
+  mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });
+  mockModule('discord.js', discordStub());
+
+  const shopModule = require(shopPath);
+  const [embed] = await shopModule.createCategoryEmbed('Player#0001', 'Misc', 1);
+  assert.ok(embed.description.includes('Mystery'));
+});


### PR DESCRIPTION
## Summary
- Resolve legacy item keys using `shop.findItemName` in category embeds
- Treat unknown items as `Misc` and default missing categories
- Add tests for canonical name remapping and misc category handling

## Testing
- `npm test` *(fails: /inventory command uses user tag identifier, panel-interactions.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689a5771c818832e80eed924573503b7