### PR TITLE
Use balance helpers in buySale

### DIFF
--- a/marketplace.js
+++ b/marketplace.js
@@ -171,11 +171,13 @@ class marketplace {
       return embed;
     }
 
-    if (charData[userTag].balance < sale.price) {
+    const buyerBalance = await dbm.getBalance(userTag);
+    if (buyerBalance < sale.price) {
       return "You don't have enough money to buy that!";
     }
-    charData[userTag].balance -= sale.price;
-    charData[sale.seller].balance += sale.price;
+    const sellerBalance = await dbm.getBalance(sale.seller);
+    await dbm.setBalance(userTag, buyerBalance - sale.price);
+    await dbm.setBalance(sale.seller, sellerBalance + sale.price);
 
     if (!charData[userTag].inventory[itemName]) {
       charData[userTag].inventory[itemName] = 0;

--- a/tests/inventory-command.test.js
+++ b/tests/inventory-command.test.js
@@ -10,7 +10,7 @@ function mockModule(modulePath, mock) {
   require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports: mock };
 }
 
-test('/inventory command uses user tag identifier', async (t) => {
+test('/inventory command uses user id identifier', async (t) => {
   let calledId;
   mockModule(path.join(root, 'shop.js'), {
     createInventoryEmbed: async (id) => { calledId = id; return [{ description: 'ok' }, []]; }
@@ -27,7 +27,7 @@ test('/inventory command uses user tag identifier', async (t) => {
   };
 
   await command.execute(interaction);
-  assert.equal(calledId, 'TestUser#0001');
+  assert.equal(calledId, '123456789012345678');
   assert.ok(replied.embeds);
 
   t.after(() => {

--- a/tests/panel-interactions.test.js
+++ b/tests/panel-interactions.test.js
@@ -100,11 +100,7 @@ function panelSelectTest(choice, expectedFn) {
     const interaction = createSelectInteraction(choice);
     await handler.handle(interaction);
     assert.equal(called.fn, expectedFn);
- wlb4yk-codex/update-inventory-database-operations-identifier
     const expectedId = expectedFn === 'inventory' ? 'TestUser#0001' : '123456789012345678';
-
-    const expectedId = expectedFn === 'inventory' ? 'stub' : 'user123';
- main
     assert.equal(called.id, expectedId);
     if (called.page) assert.equal(called.page, 1);
     const expectedEmbed = {
@@ -141,11 +137,7 @@ function paginationTest(customId, expectedFn, expectedPage) {
     const interaction = createButtonInteraction(customId);
     await handler.handle(interaction);
     assert.equal(called.fn, expectedFn);
- wlb4yk-codex/update-inventory-database-operations-identifier
     const expectedId = expectedFn === 'inventory' ? 'TestUser#0001' : '123456789012345678';
-
-    const expectedId = expectedFn === 'inventory' ? 'stub' : 'user123';
- main
     assert.deepEqual(called, { fn: expectedFn, id: expectedId, page: expectedPage });
     const expectedEmbed = {
       inventory: 'invEmbed',


### PR DESCRIPTION
## Summary
- use database balance helpers to transfer funds when buying sales
- mock balance helpers in marketplace tests and drop character balance field
- fix broken panel and inventory command tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a64acc1bc832eb5536111ce366a02