### PR TITLE
Refactor panel inventory and storage to use direct SQL queries

### DIFF
--- a/tests/panel-errors.test.js
+++ b/tests/panel-errors.test.js
@@ -51,6 +51,7 @@ test('mainEmbed returns error when character lookup fails', async (t) => {
     './clientManager.js': { getEmoji: () => ':coin:' },
     './shop.js': {},
     './char.js': {},
+    './pg-client.js': { query: async () => ({ rows: [] }) },
     'discord.js': discordStub(),
   });
   t.after(cleanup);
@@ -66,6 +67,7 @@ test('mainEmbed returns error when character data missing', async (t) => {
     './clientManager.js': { getEmoji: () => ':coin:' },
     './shop.js': {},
     './char.js': {},
+    './pg-client.js': { query: async () => ({ rows: [] }) },
     'discord.js': discordStub(),
   });
   t.after(cleanup);
@@ -82,6 +84,7 @@ test('shipsEmbed returns error when character lookup fails', async (t) => {
     './shop.js': {
       createCategoryEmbed: async () => [{ description: 'Character not found.' }, []],
     },
+    './pg-client.js': { query: async () => ({ rows: [] }) },
     'discord.js': discordStub(),
   });
   t.after(cleanup);


### PR DESCRIPTION
## Summary
- Inline inventory and storage embed logic to query `v_inventory` directly
- Filter categories and format results with existing pagination
- Adjust panel tests to mock new database access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b45810058832e83b48ab470b2fb0b