### PR TITLE
Migrate inventory reads to v_inventory and add dbcheck command

### DIFF
--- a/commands/testCommands/dbcheck.js
+++ b/commands/testCommands/dbcheck.js
@@ -1,0 +1,61 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const db = require('../../pg-client');
+const dataGetters = require('../../dataGetters');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('dbcheck')
+    .setDescription('Debug: show items from v_inventory for your character')
+    .addStringOption(opt =>
+      opt.setName('character_id')
+        .setDescription('Optional: override character id')
+        .setRequired(false)
+    ),
+  async execute(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const provided = interaction.options.getString('character_id') ?? undefined;
+    const resolved = provided ?? await dataGetters.getCharFromNumericID(interaction.user.tag);
+    const characterId = resolved === 'ERROR' ? undefined : resolved;
+
+    if (!characterId) {
+      await interaction.editReply('No character_id found. Provide one with `/dbcheck character_id:<id>`.');
+      return;
+    }
+
+    let rows;
+    try {
+      const res = await db.query(
+        `SELECT character_id, item_id, quantity, name, category
+           FROM v_inventory
+           WHERE character_id = $1
+           ORDER BY category, name`,
+        [characterId]
+      );
+      rows = res.rows;
+    } catch (err) {
+      await interaction.editReply(`DB error while reading v_inventory: ${err.message || err}`);
+      return;
+    }
+
+    if (!rows.length) {
+      await interaction.editReply(`No items found in v_inventory for \`${characterId}\`.`);
+      return;
+    }
+
+    const lines = rows.map(r => `• **${r.name}** (${r.item_id}) — x${r.quantity} _[${r.category}]_`);
+    const chunks = [];
+    for (let i = 0; i < lines.length; i += 20) {
+      chunks.push(lines.slice(i, i + 20).join('\n'));
+    }
+
+    const embeds = chunks.map((chunk, idx) =>
+      new EmbedBuilder()
+        .setTitle(`v_inventory for ${characterId} (${idx + 1}/${chunks.length})`)
+        .setDescription(chunk)
+        .setTimestamp(new Date())
+    );
+
+    await interaction.editReply({ embeds });
+  }
+};

--- a/tests/buy-item-inventory.test.js
+++ b/tests/buy-item-inventory.test.js
@@ -57,9 +57,6 @@ test('buyItem stores stacks in inventory_items via transaction', async () => {
       const t = {
         query: async (text, params) => {
           executed.push(text);
-          if (/INSERT INTO inventories/i.test(text)) {
-            return { rows: [{ id: 1 }] };
-          }
           return { rows: [] };
         }
       };
@@ -77,7 +74,7 @@ test('buyItem stores stacks in inventory_items via transaction', async () => {
 
   const reply = await shopModule.buyItem('Apple', 'Player#0001', 2, 'channel');
   assert.equal(reply, 'Succesfully bought 2 Apple');
-  assert.ok(executed.some(q => /INSERT INTO inventories/i.test(q)));
+  assert.ok(!executed.some(q => /INSERT INTO inventories/i.test(q)));
   assert.ok(executed.some(q => /INSERT INTO inventory_items/i.test(q)));
   assert.ok(!saveCalled);
   assert.strictEqual(charData.inventory, undefined);

--- a/tests/inventory-items.test.js
+++ b/tests/inventory-items.test.js
@@ -27,22 +27,19 @@ function mockModule(modulePath, mock) {
 
 test('inventory embed shows non-stackable items', async () => {
   const charData = {
-    'Player#0001': { numericID: 'player1', inventory: {} }
+    'Player#0001': { numericID: 'player1' }
   };
   const shopData = {
     Sword: { infoOptions: { Category: 'Weapons', Icon: ':sword:' } }
   };
-  let invId, instId;
   const dbmStub = {
     loadCollection: async (col) => (col === 'characters' ? charData : shopData),
     saveCollection: async () => {},
-    getInventory: async (id) => { invId = id; return {}; },
-    getInventoryItems: async (id) => { instId = id; return [{ item_id: 'Sword' }]; },
   };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
   mockModule(path.join(root, 'database-manager.js'), dbmStub);
-  mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [] }) });
+  mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [{ character_id:'Player#0001', item_id:'Sword', quantity:1, name:'Sword', category:'Weapons' }] }) });
   mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
   mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
   mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });
@@ -51,13 +48,11 @@ test('inventory embed shows non-stackable items', async () => {
   const shopModule = require(shopPath);
   const [embed] = await shopModule.createInventoryEmbed('Player#0001', 1);
   assert.ok(embed.description.includes('Sword'));
-  assert.equal(invId, 'Player#0001');
-  assert.equal(instId, 'Player#0001');
 });
 
 test('inventory embed includes legacy inline inventory', async () => {
   const charData = {
-    'Player#0001': { numericID: 'player1', inventory: { Apple: 2 } }
+    'Player#0001': { numericID: 'player1' }
   };
   const shopData = {
     Apple: { infoOptions: { Category: 'Food', Icon: ':apple:' } }
@@ -65,13 +60,11 @@ test('inventory embed includes legacy inline inventory', async () => {
   const dbmStub = {
     loadCollection: async (col) => (col === 'characters' ? charData : shopData),
     saveCollection: async () => {},
-    getInventory: async () => ({}),
-    getInventoryItems: async () => [],
   };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
   mockModule(path.join(root, 'database-manager.js'), dbmStub);
-  mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [] }) });
+  mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [{ character_id:'Player#0001', item_id:'Apple', quantity:2, name:'Apple', category:'Food' }] }) });
   mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
   mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
   mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });

--- a/tests/storage-normalized.test.js
+++ b/tests/storage-normalized.test.js
@@ -30,30 +30,26 @@ function mockModule(modulePath, mock) {
 test('storage uses normalized inventory when legacy storage empty', async () => {
   const charData = {
     'Player#0001': {
-      inventory: {},
       numericID: 'player1'
     }
   };
   const shopData = {
     Wood: { infoOptions: { Category: 'Resources', Icon: ':wood:' } }
   };
-  let invId;
   const dbmStub = {
     loadCollection: async (col) => (col === 'characters' ? charData : shopData),
     saveCollection: async () => {},
-    getInventory: async (id) => { invId = id; return { Wood: 10 }; }
   };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
   mockModule(path.join(root, 'database-manager.js'), dbmStub);
-  mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [] }) });
+  mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [{ character_id:'Player#0001', item_id:'Wood', quantity:10, name:'Wood', category:'Resources' }] }) });
   mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
   mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
   mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });
   mockModule('discord.js', discordStub());
 
   const shopModule = require(shopPath);
-  const [embed] = await shopModule.createCategoryEmbed('Player#0001', 'Resources', 1, 'panel_store_page', 'storage');
+  const [embed] = await shopModule.createCategoryEmbed('Player#0001', 'Resources', 1, 'panel_store_page');
   assert.ok(embed.description.includes('Wood'));
-  assert.equal(invId, 'Player#0001');
 });


### PR DESCRIPTION
## Summary
- use unified `v_inventory` view for panel and shop inventory queries
- write purchased items directly into `inventory_items`
- add `/dbcheck` debug command to inspect `v_inventory`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b910856c8832eaef65caa40843f5b