### PR TITLE
Refactor addItemToPlayer to insert inventory records

### DIFF
--- a/commands/charCommands/additemstoplayer.js
+++ b/commands/charCommands/additemstoplayer.js
@@ -15,14 +15,11 @@ module.exports = {
         const player = interaction.options.getUser('player').toString();
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');
-        const response = await char.addItemToPlayer(player, item, amount);
-
-        if (response == true) {
-            return interaction.reply(`Gave ${amount} ${item} to ${player}`);
-        } else if (response == false || !response) {
-            return interaction.reply('Something went wrong');
-        } else {
-            return interaction.reply(response);
+        try {
+            const canonical = await char.addItemToPlayer(player, item, amount);
+            return interaction.reply(`Gave ${amount} ${canonical} to ${player}`);
+        } catch (err) {
+            return interaction.reply(err.message || 'Something went wrong');
         }
     },
 };

--- a/commands/charCommands/takeitemsfromplayer.js
+++ b/commands/charCommands/takeitemsfromplayer.js
@@ -15,14 +15,11 @@ module.exports = {
         const player = interaction.options.getUser('player').toString();
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');
-        const response = await char.addItemToPlayer(player, item, -amount);
-
-        if (response == true) {
-            return interaction.reply(`Took ${amount} ${item} from ${player}`);
-        } else if (response == false || !response) {
-            return interaction.reply('Something went wrong');
-        } else {
-            return interaction.reply(response);
+        try {
+            const canonical = await char.addItemToPlayer(player, item, -amount);
+            return interaction.reply(`Took ${amount} ${canonical} from ${player}`);
+        } catch (err) {
+            return interaction.reply(err.message || 'Something went wrong');
         }
     },
 };


### PR DESCRIPTION
## Summary
- insert inventory rows instead of mutating character JSON
- handle errors and return canonical item name from addItemToPlayer
- update admin item commands for new async DB insert/delete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b9e819324832e8ab3a307b712879d