### PR TITLE
Add inventory grant helpers and item resolution

### DIFF
--- a/inventory-grants.js
+++ b/inventory-grants.js
@@ -1,0 +1,34 @@
+async function resolveItemId(client, key) {
+  const { rows } = await client.query(
+    `SELECT id FROM items
+       WHERE LOWER(id) = LOWER($1)
+          OR LOWER(data->>'name') = LOWER($1)
+          OR LOWER(data->>'Name') = LOWER($1)
+          OR LOWER(data->'infoOptions'->>'Name') = LOWER($1)
+       LIMIT 1`,
+    [key]
+  );
+  if (!rows[0]) {
+    throw new Error('Item not found');
+  }
+  return rows[0].id;
+}
+
+async function grantItemToPlayer(client, characterId, itemKey, qty) {
+  if (qty <= 0) {
+    throw new Error('qty must be positive');
+  }
+  const itemId = await resolveItemId(client, itemKey);
+  await client.query(
+    `INSERT INTO inventory_items (instance_id, owner_id, item_id)
+       SELECT md5(random()::text), $1, $2
+         FROM generate_series(1, $3::int)`,
+    [characterId, itemId, qty]
+  );
+  return itemId;
+}
+
+module.exports = {
+  resolveItemId,
+  grantItemToPlayer,
+};

--- a/tests/inventory-grants.test.js
+++ b/tests/inventory-grants.test.js
@@ -1,0 +1,55 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { newDb, DataType } = require('pg-mem');
+
+const { resolveItemId } = require('../inventory-grants');
+
+function setup() {
+  const db = newDb();
+  db.public.registerFunction({
+    name: 'generate_series',
+    args: [DataType.integer, DataType.integer],
+    returns: DataType.integer,
+    implementation: function* (start, end) {
+      for (let i = start; i <= end; i++) {
+        yield i;
+      }
+    },
+    impure: true,
+  });
+  db.public.registerFunction({
+    name: 'random',
+    args: [],
+    returns: DataType.float,
+    implementation: Math.random,
+    impure: true,
+  });
+  const crypto = require('crypto');
+  db.public.registerFunction({
+    name: 'md5',
+    args: [DataType.text],
+    returns: DataType.text,
+    implementation: (str) => crypto.createHash('md5').update(str).digest('hex'),
+    impure: false,
+  });
+  const pgMem = db.adapters.createPg();
+  const pool = new pgMem.Pool();
+  return { pool };
+}
+
+test('resolveItemId matches by id and case-insensitive name', async () => {
+  const { pool } = setup();
+
+  await pool.query('CREATE TABLE items (id TEXT PRIMARY KEY, data JSONB)');
+  await pool.query('CREATE TABLE inventory_items (instance_id TEXT PRIMARY KEY, owner_id TEXT, item_id TEXT)');
+  await pool.query("INSERT INTO items (id, data) VALUES ($1, $2)", ['wood_sword', { infoOptions: { Name: 'Wood Sword' } }]);
+
+  const client = { query: (text, params) => pool.query(text, params) };
+
+  const byId = await resolveItemId(client, 'wood_sword');
+  assert.equal(byId, 'wood_sword');
+
+  const byName = await resolveItemId(client, 'Wood Sword');
+  assert.equal(byName, 'wood_sword');
+});
+


### PR DESCRIPTION
## Summary
- add helper functions for resolving item IDs and granting items to players
- validate case-insensitive item lookups with a unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bb926b780832eb2ea06bbfaa2e6b1