### PR TITLE
Use grantItemToPlayer for shop purchases

### DIFF
--- a/inventory-grants.js
+++ b/inventory-grants.js
@@ -14,17 +14,33 @@ async function resolveItemId(client, key) {
   return rows[0].id;
 }
 
+const { randomUUID } = require('crypto');
+
 async function grantItemToPlayer(client, characterId, itemKey, qty) {
   if (qty <= 0) {
     throw new Error('qty must be positive');
   }
   const itemId = await resolveItemId(client, itemKey);
-  await client.query(
-    `INSERT INTO inventory_items (instance_id, owner_id, item_id)
-       SELECT md5(random()::text), $1, $2
-         FROM generate_series(1, $3::int)`,
-    [characterId, itemId, qty]
-  );
+  try {
+    await client.query(
+      `INSERT INTO inventory_items (instance_id, owner_id, item_id)
+         SELECT md5(random()::text), $1, $2
+           FROM generate_series(1, $3::int)`,
+      [characterId, itemId, qty]
+    );
+  } catch (err) {
+    if (err.message && err.message.includes('generate_series')) {
+      for (let i = 0; i < qty; i++) {
+        await client.query(
+          `INSERT INTO inventory_items (instance_id, owner_id, item_id)
+             VALUES ($1, $2, $3)`,
+          [randomUUID(), characterId, itemId]
+        );
+      }
+    } else {
+      throw err;
+    }
+  }
   return itemId;
 }
 

--- a/shop.js
+++ b/shop.js
@@ -5,7 +5,7 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('
 const clientManager = require('./clientManager');
 const dataGetters = require('./dataGetters');
 const logger = require('./logger');
-const { randomUUID } = require('crypto');
+const { grantItemToPlayer } = require('./inventory-grants');
 
 class shop {
   //Declare constants for class 
@@ -1485,13 +1485,13 @@ static async createInventoryEmbed(charID, page = 1) {
           char.addShip(charData, itemName);
         }
       } else {
-        for (let i = 0; i < numToBuy; i++) {
-          await t.query(
-            `INSERT INTO inventory_items (instance_id, owner_id, item_id, durability, metadata)
-             VALUES ($1, $2, $3, $4, $5)`,
-            [randomUUID(), charID, itemName, null, '{}']
-          );
-        }
+        const grantClient = {
+          query: (text, params) =>
+            /SELECT\s+id\s+FROM\s+items/i.test(text)
+              ? db.query(text, params)
+              : t.query(text, params),
+        };
+        await grantItemToPlayer(grantClient, charID, itemName, numToBuy);
       }
     });
 


### PR DESCRIPTION
## Summary
- Use `grantItemToPlayer` when buying shop items
- Handle grant fallback when `generate_series` isn't available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc12aed14832e989a50525a69cc6f