### PR TITLE
Add ensureItem helper for canonical inventory IDs

### DIFF
--- a/tests/buy-item-inventory.test.js
+++ b/tests/buy-item-inventory.test.js
@@ -52,11 +52,19 @@ test('buyItem stores stacks in inventory_items via transaction', async () => {
 
   const executed = [];
   const dbStub = {
-    query: async () => ({ rows: [{ id: 'Apple' }] }),
+    query: async (text) => {
+      if (/resolve_item_id/i.test(text)) {
+        return { rows: [{ canon_id: 'Apple' }] };
+      }
+      return { rows: [{ id: 'Apple' }] };
+    },
     tx: async (cb) => {
       const t = {
         query: async (text, params) => {
           executed.push(text);
+          if (/resolve_item_id/i.test(text)) {
+            return { rows: [{ canon_id: 'Apple' }] };
+          }
           return { rows: [] };
         }
       };

--- a/tests/inventory-grants.test.js
+++ b/tests/inventory-grants.test.js
@@ -2,54 +2,91 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { newDb, DataType } = require('pg-mem');
 
-const { resolveItemId } = require('../inventory-grants');
+const { ensureItem, grantItemToPlayer } = require('../inventory-grants');
 
-function setup() {
+function setup({ series = true } = {}) {
   const db = newDb();
+
+  if (series) {
+    db.public.registerFunction({
+      name: 'generate_series',
+      args: [DataType.integer, DataType.integer],
+      returns: DataType.integer,
+      implementation: function* (start, end) {
+        for (let i = start; i <= end; i++) {
+          yield i;
+        }
+      },
+      impure: true,
+    });
+
+    db.public.registerFunction({
+      name: 'random',
+      args: [],
+      returns: DataType.float,
+      implementation: Math.random,
+      impure: true,
+    });
+
+    const crypto = require('crypto');
+    db.public.registerFunction({
+      name: 'md5',
+      args: [DataType.text],
+      returns: DataType.text,
+      implementation: (str) => crypto.createHash('md5').update(str).digest('hex'),
+      impure: false,
+    });
+  }
+
   db.public.registerFunction({
-    name: 'generate_series',
-    args: [DataType.integer, DataType.integer],
-    returns: DataType.integer,
-    implementation: function* (start, end) {
-      for (let i = start; i <= end; i++) {
-        yield i;
-      }
-    },
-    impure: true,
-  });
-  db.public.registerFunction({
-    name: 'random',
-    args: [],
-    returns: DataType.float,
-    implementation: Math.random,
-    impure: true,
-  });
-  const crypto = require('crypto');
-  db.public.registerFunction({
-    name: 'md5',
+    name: 'resolve_item_id',
     args: [DataType.text],
     returns: DataType.text,
-    implementation: (str) => crypto.createHash('md5').update(str).digest('hex'),
+    implementation: (raw) => raw.toLowerCase().replace(/\s+/g, '_'),
     impure: false,
   });
+
   const pgMem = db.adapters.createPg();
   const pool = new pgMem.Pool();
   return { pool };
 }
 
-test('resolveItemId matches by id and case-insensitive name', async () => {
+test('ensureItem resolves canon id and inserts row when missing', async () => {
   const { pool } = setup();
 
-  await pool.query('CREATE TABLE items (id TEXT PRIMARY KEY, data JSONB)');
-  await pool.query('CREATE TABLE inventory_items (instance_id TEXT PRIMARY KEY, owner_id TEXT, item_id TEXT)');
-  await pool.query("INSERT INTO items (id, data) VALUES ($1, $2)", ['wood_sword', { infoOptions: { Name: 'Wood Sword' } }]);
+  await pool.query('CREATE TABLE items (id TEXT PRIMARY KEY, category TEXT, data JSONB)');
 
   const client = { query: (text, params) => pool.query(text, params) };
 
-  const byId = await resolveItemId(client, 'wood_sword');
-  assert.equal(byId, 'wood_sword');
+  const canon = await ensureItem(client, 'Wood Sword', 'Weapons');
+  assert.equal(canon, 'wood_sword');
 
-  const byName = await resolveItemId(client, 'Wood Sword');
-  assert.equal(byName, 'wood_sword');
+  const { rows } = await pool.query('SELECT id, category, data FROM items');
+  assert.deepEqual(rows, [{ id: 'wood_sword', category: 'Weapons', data: {} }]);
+
+  // Calling again should not change existing row
+  await ensureItem(client, 'Wood Sword', 'Misc');
+  const { rows: rows2 } = await pool.query('SELECT id, category FROM items');
+  assert.equal(rows2.length, 1);
+  assert.equal(rows2[0].category, 'Weapons');
+});
+
+test('grantItemToPlayer ensures item and inserts instances', async () => {
+  const { pool } = setup({ series: false });
+
+  await pool.query('CREATE TABLE items (id TEXT PRIMARY KEY, category TEXT, data JSONB)');
+  await pool.query('CREATE TABLE inventory_items (instance_id TEXT PRIMARY KEY, owner_id TEXT, item_id TEXT)');
+
+  const client = { query: (text, params) => pool.query(text, params) };
+
+  const canon = await grantItemToPlayer(client, 'char1', 'Wood', 2);
+  assert.equal(canon, 'wood');
+
+  const { rows: itemRows } = await pool.query('SELECT id, category FROM items');
+  assert.deepEqual(itemRows, [{ id: 'wood', category: 'Misc' }]);
+
+  const { rows: invRows } = await pool.query('SELECT owner_id, item_id FROM inventory_items');
+  assert.equal(invRows.length, 2);
+  assert.ok(invRows.every((r) => r.owner_id === 'char1' && r.item_id === 'wood'));
 });
 

--- a/tests/inventory-view.test.js
+++ b/tests/inventory-view.test.js
@@ -33,8 +33,15 @@ const root = path.join(__dirname, '..');
 const shopPath = path.join(root, 'shop.js');
 
 async function setupTest(itemName, category) {
-  const { newDb } = require('pg-mem');
+const { newDb, DataType } = require('pg-mem');
   const mem = newDb();
+  mem.public.registerFunction({
+    name: 'resolve_item_id',
+    args: [DataType.text],
+    returns: DataType.text,
+    implementation: (raw) => raw,
+    impure: false,
+  });
   const pgMem = mem.adapters.createPg();
   const pool = new pgMem.Pool();
 


### PR DESCRIPTION
## Summary
- add ensureItem helper to resolve canonical item IDs and upsert missing items
- use ensureItem in grantItemToPlayer and char inventory helpers
- update tests for canonical ID handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c5513df00832e968fd0abb13be4d5