### PR TITLE
Use canonical item IDs for shop purchases

### DIFF
--- a/inventory-grants.js
+++ b/inventory-grants.js
@@ -13,11 +13,10 @@ async function ensureItem(client, raw, category = 'Misc') {
 
 const { randomUUID } = require('crypto');
 
-async function grantItemToPlayer(client, characterId, itemKey, qty) {
+async function grantItemToPlayer(client, characterId, itemId, qty) {
   if (qty <= 0) {
     throw new Error('qty must be positive');
   }
-  const itemId = await ensureItem(client, itemKey);
   try {
     await client.query(
       `INSERT INTO inventory_items (instance_id, owner_id, item_id)

--- a/tests/inventory-grants.test.js
+++ b/tests/inventory-grants.test.js
@@ -79,14 +79,15 @@ test('grantItemToPlayer ensures item and inserts instances', async () => {
 
   const client = { query: (text, params) => pool.query(text, params) };
 
-  const canon = await grantItemToPlayer(client, 'char1', 'Wood', 2);
+  const canon = await ensureItem(client, 'Wood', 'Misc');
   assert.equal(canon, 'wood');
+  await grantItemToPlayer(client, 'char1', canon, 2);
 
   const { rows: itemRows } = await pool.query('SELECT id, category FROM items');
-  assert.deepEqual(itemRows, [{ id: 'wood', category: 'Misc' }]);
+  assert.deepEqual(itemRows, [{ id: canon, category: 'Misc' }]);
 
   const { rows: invRows } = await pool.query('SELECT owner_id, item_id FROM inventory_items');
   assert.equal(invRows.length, 2);
-  assert.ok(invRows.every((r) => r.owner_id === 'char1' && r.item_id === 'wood'));
+  assert.ok(invRows.every((r) => r.owner_id === 'char1' && r.item_id === canon));
 });
 

--- a/tests/inventory-view.test.js
+++ b/tests/inventory-view.test.js
@@ -48,7 +48,7 @@ const { newDb, DataType } = require('pg-mem');
   await pool.query('CREATE TABLE balances (id TEXT PRIMARY KEY, amount INTEGER DEFAULT 0)');
   await pool.query('CREATE TABLE items (id TEXT PRIMARY KEY, category TEXT, data JSONB)');
   await pool.query('CREATE TABLE inventory_items (instance_id TEXT PRIMARY KEY, owner_id TEXT, item_id TEXT, durability INTEGER, metadata JSONB)');
-  await pool.query('CREATE TABLE shop (id TEXT PRIMARY KEY)');
+  await pool.query('CREATE TABLE shop (id TEXT PRIMARY KEY, data JSONB)');
   await pool.query(`CREATE VIEW v_inventory AS
     SELECT ii.owner_id AS character_id,
            ii.item_id,
@@ -60,17 +60,9 @@ const { newDb, DataType } = require('pg-mem');
      GROUP BY ii.owner_id, ii.item_id, it.category`);
 
   await pool.query('INSERT INTO items (id, category, data) VALUES ($1, $2, $3)', [itemName, category, {}]);
-  await pool.query('INSERT INTO shop (id) VALUES ($1)', [itemName]);
-
-  const shopData = {
-    [itemName]: {
-      infoOptions: { Category: category },
-      shopOptions: { 'Price (#)': 10, Channels: '', 'Need Role': '', 'Give Role': '' }
-    }
-  };
+  await pool.query('INSERT INTO shop (id, data) VALUES ($1, $2)', [itemName, { item_id: itemName, price: '10', channels: '', need_role: '', give_role: '' }]);
 
   const dbmStub = {
-    loadCollection: async (col) => (col === 'shop' ? shopData : {}),
     loadFile: async () => ({ numericID: 'usernum' }),
     getBalance: async () => 100,
     saveFile: async () => {}


### PR DESCRIPTION
## Summary
- query shop table for `item_id` and `price` from JSON data
- resolve each item ID defensively and pass canonical ID to `grantItemToPlayer`
- adjust `grantItemToPlayer` to accept canonical IDs and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5929abe0832e88ce00c0fbe3b2d4