### PR TITLE
feat: add canonical item fields and price handling

### DIFF
--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -31,7 +31,7 @@ const addItem = async (interaction) => {
     const itemId = await ensureItem(db, itemName, itemCategory);
     const rowId = randomUUID();
     await db.query(
-      `INSERT INTO shop (id, data) VALUES ($1, jsonb_build_object('name',$2,'price',$3,'item_id',$4)) ON CONFLICT (id) DO UPDATE SET data=EXCLUDED.data`,
+      `INSERT INTO shop (id, data) VALUES ($1, jsonb_build_object('name',$2,'price',$3,'item_id',$4,'item',$4)) ON CONFLICT (id) DO UPDATE SET data=EXCLUDED.data`,
       [rowId, itemName, priceInt, itemId]
     );
     await interaction.reply({content: `Item '${itemName}' has been added to the item list. Use /shoplayout or ping Alex to add to shop.`, ephemeral: true});

--- a/marketplace.js
+++ b/marketplace.js
@@ -39,7 +39,7 @@ class marketplace {
       return "You don't have enough of that item to sell it!";
     }
     charData.inventory[itemName] -= numberItems;
-    const saleData = { item_id: itemName, price, quantity: numberItems };
+    const saleData = { item_id: itemName, item: itemName, price, quantity: numberItems };
     const res = await db.query(
       'INSERT INTO marketplace (name, data, seller, seller_id) VALUES ($1,$2,$3,$4) RETURNING id',
       [itemName, saleData, userTag, userID]
@@ -75,7 +75,9 @@ class marketplace {
     for (const sale of rows) {
       const itemId = sale.item_id || sale.item || sale.data?.item_id;
       const quantity = Number(sale.data?.quantity ?? 0);
-      const price = Number(sale.price ?? sale.data?.price ?? 0);
+      const price = Number(
+        sale.price ?? sale.data?.price ?? sale.data?.shopOptions?.['Price (#)'] ?? 0
+      );
       const itemName = sale.name || itemId;
       const icon = await shop.getItemIcon(itemId, shopData);
       let alignSpaces = ' ';
@@ -131,7 +133,9 @@ class marketplace {
     for (const sale of rows) {
       const itemId = sale.item_id || sale.item || sale.data?.item_id;
       const quantity = Number(sale.data?.quantity ?? 0);
-      const price = Number(sale.price ?? sale.data?.price ?? 0);
+      const price = Number(
+        sale.price ?? sale.data?.price ?? sale.data?.shopOptions?.['Price (#)'] ?? 0
+      );
       const itemName = sale.name || itemId;
       const icon = await shop.getItemIcon(itemId, shopData);
       let alignSpaces = ' ';
@@ -158,7 +162,9 @@ class marketplace {
       return "Character not found!";
     }
     const quantity = Number(sale.data?.quantity ?? 0);
-    const price = Number(sale.price ?? sale.data?.price ?? 0);
+    const price = Number(
+      sale.price ?? sale.data?.price ?? sale.data?.shopOptions?.['Price (#)'] ?? 0
+    );
     if (quantity < 0 || price < 0) {
       return "That sale has invalid data!";
     }
@@ -204,7 +210,9 @@ class marketplace {
     }
     const itemId = sale.item_id || sale.item || sale.data?.item_id;
     const quantity = Number(sale.data?.quantity ?? 0);
-    const price = Number(sale.price ?? sale.data?.price ?? 0);
+    const price = Number(
+      sale.price ?? sale.data?.price ?? sale.data?.shopOptions?.['Price (#)'] ?? 0
+    );
     let embed = new EmbedBuilder();
     embed.setTitle(`Sale ${saleID}`);
     embed.setColor(0x36393e);

--- a/seed-data/shop.json
+++ b/seed-data/shop.json
@@ -1,5 +1,8 @@
 {
   "Wood": {
+    "item_id": "Wood",
+    "item": "Wood",
+    "price": 1,
     "infoOptions": {
       "Name": "Wood",
       "Icon": "🪵",
@@ -9,7 +12,6 @@
       "Transferrable (Y/N)": "Yes"
     },
     "shopOptions": {
-      "Price (#)": 1,
       "Need Role": "",
       "Give Role": "",
       "Take Role": "",
@@ -49,6 +51,9 @@
     }
   },
   "Alloy Frame Modules": {
+    "item_id": "Alloy Frame Modules",
+    "item": "Alloy Frame Modules",
+    "price": 10,
     "infoOptions": {
       "Name": "Alloy Frame Modules",
       "Icon": "⚙️",
@@ -58,7 +63,6 @@
       "Transferrable (Y/N)": "Yes"
     },
     "shopOptions": {
-      "Price (#)": 10,
       "Need Role": "",
       "Give Role": "",
       "Take Role": "",
@@ -98,6 +102,9 @@
     }
   },
   "Plasma Core Cells": {
+    "item_id": "Plasma Core Cells",
+    "item": "Plasma Core Cells",
+    "price": 10,
     "infoOptions": {
       "Name": "Plasma Core Cells",
       "Icon": "🔋",
@@ -107,7 +114,6 @@
       "Transferrable (Y/N)": "Yes"
     },
     "shopOptions": {
-      "Price (#)": 10,
       "Need Role": "",
       "Give Role": "",
       "Take Role": "",


### PR DESCRIPTION
## Summary
- include item_id and price at top level for shop seed items
- mirror item_id to item for backward compatibility
- prefer top-level price field across shop and marketplace, falling back to legacy shopOptions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca387c070832e87d3889f665a25a9