### PR TITLE
refactor shop metadata access

### DIFF
--- a/marketplace.js
+++ b/marketplace.js
@@ -30,7 +30,8 @@ class marketplace {
       return "That item doesn't exist!";
     }
 
-    if (shopData[itemName].infoOptions["Transferrable (Y/N)"] == "No") {
+    const meta = await shop.getItemMetadata(itemName, shopData);
+    if (meta?.transferrable === 'No') {
       return "That item is not transferrable!";
     }
 
@@ -47,7 +48,7 @@ class marketplace {
     const itemID = res.rows[0].id;
     await dbm.saveFile('characters', userTag, charData);
     let embed = new EmbedBuilder();
-    embed.setDescription(`<@${userID}> listed **${numberItems} ${await shop.getItemIcon(itemName, shopData)} ${itemName}** to the **/sales** page for ${clientManager.getEmoji("Gold")}**${price}**.`);
+    embed.setDescription(`<@${userID}> listed **${numberItems} ${meta.icon} ${itemName}** to the **/sales** page for ${clientManager.getEmoji("Gold")}**${price}**.`);
     embed.setFooter({ text: `Sale ID: ${itemID}` });
     return embed;
   }
@@ -78,8 +79,9 @@ class marketplace {
       const price = Number(
         sale.price ?? sale.data?.price ?? sale.data?.shopOptions?.['Price (#)'] ?? 0
       );
-      const itemName = sale.name || itemId;
-      const icon = await shop.getItemIcon(itemId, shopData);
+      const meta = await shop.getItemMetadata(itemId, shopData);
+      const itemName = sale.name || meta?.name || itemId;
+      const icon = meta?.icon || '';
       let alignSpaces = ' ';
       if (20 - itemName.length - ('' + price + '' + quantity).length > 0) {
         alignSpaces = ' '.repeat(20 - itemName.length - ('' + price + '' + quantity).length);
@@ -136,8 +138,9 @@ class marketplace {
       const price = Number(
         sale.price ?? sale.data?.price ?? sale.data?.shopOptions?.['Price (#)'] ?? 0
       );
-      const itemName = sale.name || itemId;
-      const icon = await shop.getItemIcon(itemId, shopData);
+      const meta = await shop.getItemMetadata(itemId, shopData);
+      const itemName = sale.name || meta?.name || itemId;
+      const icon = meta?.icon || '';
       let alignSpaces = ' ';
       if (30 - itemName.length - ('' + price + '' + quantity).length > 0) {
         alignSpaces = ' '.repeat(30 - itemName.length - ('' + price + '' + quantity).length);
@@ -177,7 +180,8 @@ class marketplace {
       await db.query('DELETE FROM marketplace WHERE id=$1', [saleID]);
       await dbm.saveCollection('characters', charData);
       let embed = new EmbedBuilder();
-      embed.setDescription(`<@${userID}> bought **${quantity} ${await shop.getItemIcon(itemId, shopData)} ${itemId}** back from themselves. It was listed for ${clientManager.getEmoji("Gold")}**${price}**.`);
+      const meta = await shop.getItemMetadata(itemId, shopData);
+      embed.setDescription(`<@${userID}> bought **${quantity} ${meta?.icon || ''} ${itemId}** back from themselves. It was listed for ${clientManager.getEmoji("Gold")}**${price}**.`);
       return embed;
     }
 
@@ -197,7 +201,8 @@ class marketplace {
     await db.query('DELETE FROM marketplace WHERE id=$1', [saleID]);
     await dbm.saveCollection('characters', charData);
     let embed = new EmbedBuilder();
-    embed.setDescription(`<@${userID}> bought **${quantity} ${await shop.getItemIcon(itemId, shopData)} ${itemId}** from<@${sale.seller_id}> for ${clientManager.getEmoji("Gold")}**${price}**.`);
+    const metaPurchase = await shop.getItemMetadata(itemId, shopData);
+    embed.setDescription(`<@${userID}> bought **${quantity} ${metaPurchase?.icon || ''} ${itemId}** from<@${sale.seller_id}> for ${clientManager.getEmoji("Gold")}**${price}**.`);
     return embed;
   }
 
@@ -216,7 +221,8 @@ class marketplace {
     let embed = new EmbedBuilder();
     embed.setTitle(`Sale ${saleID}`);
     embed.setColor(0x36393e);
-    embed.setDescription(`**${quantity} ${await shop.getItemIcon(itemId, shopData)} ${itemId}** for ${clientManager.getEmoji("Gold")}**${price}**.`);
+    const metaInspect = await shop.getItemMetadata(itemId, shopData);
+    embed.setDescription(`**${quantity} ${metaInspect?.icon || ''} ${itemId}** for ${clientManager.getEmoji("Gold")}**${price}**.`);
     embed.setFooter({ text: `Seller: ${sale.seller}` });
     return embed;
   }

--- a/panel.js
+++ b/panel.js
@@ -84,7 +84,7 @@ module.exports = {
       }
       const category = row.category || 'Misc';
       if (!inventory[category]) inventory[category] = [];
-      const icon = shopData[row.item_id]?.infoOptions?.Icon || '';
+      const icon = shopData[row.item_id]?.data?.icon ?? shopData[row.item_id]?.infoOptions?.Icon ?? '';
       inventory[category].push({ item: row.name, qty: Number(row.quantity), icon });
     }
 
@@ -192,7 +192,7 @@ module.exports = {
       .map((r) => ({
         item: r.name,
         qty: Number(r.quantity),
-        icon: shopData[r.item_id]?.infoOptions?.Icon || '',
+        icon: shopData[r.item_id]?.data?.icon ?? shopData[r.item_id]?.infoOptions?.Icon ?? '',
       }))
       .sort((a, b) => a.item.localeCompare(b.item));
 

--- a/tests/create-category-embed.test.js
+++ b/tests/create-category-embed.test.js
@@ -31,7 +31,7 @@ test('createCategoryEmbed shows items for category', async () => {
   delete require.cache[require.resolve(shopPath)];
 
   const charData = { 'Player#0001': { numericID: 'player1' } };
-  const shopData = { Wood: { infoOptions: { Category: 'Resources', Icon: ':wood:' } } };
+  const shopData = { Wood: { data: { category: 'Resources', icon: ':wood:' } } };
   const dbmStub = {
     loadCollection: async (col) => (col === 'characters' ? charData : shopData),
     saveCollection: async () => {},
@@ -54,7 +54,7 @@ test('createCategoryEmbed handles misc category', async () => {
   delete require.cache[require.resolve(shopPath)];
 
   const charData = { 'Player#0001': { numericID: 'player1' } };
-  const shopData = { Mystery: { infoOptions: { Category: 'Misc', Icon: ':?' } } };
+  const shopData = { Mystery: { data: { category: 'Misc', icon: ':?' } } };
   const dbmStub = {
     loadCollection: async (col) => (col === 'characters' ? charData : shopData),
     saveCollection: async () => {},

--- a/tests/give-ship.test.js
+++ b/tests/give-ship.test.js
@@ -53,7 +53,7 @@ test('transferring a ship gives it to ships collection only', async () => {
       if (target.inventory[item] <= 0) delete target.inventory[item];
     },
     getItemDefinition: async () => ({
-      infoOptions: { Category: 'Ships', 'Transferrable (Y/N)': 'Yes' }
+      data: { category: 'Ships', transferrable: 'Yes' }
     })
   };
 

--- a/tests/inventory-items.test.js
+++ b/tests/inventory-items.test.js
@@ -30,7 +30,7 @@ test('inventory embed shows non-stackable items', async () => {
     'Player#0001': { numericID: 'player1' }
   };
   const shopData = {
-    Sword: { infoOptions: { Category: 'Weapons', Icon: ':sword:' } }
+    Sword: { data: { category: 'Weapons', icon: ':sword:' } }
   };
   const dbmStub = {
     loadCollection: async (col) => (col === 'characters' ? charData : shopData),
@@ -55,7 +55,7 @@ test('inventory embed includes legacy inline inventory', async () => {
     'Player#0001': { numericID: 'player1' }
   };
   const shopData = {
-    Apple: { infoOptions: { Category: 'Food', Icon: ':apple:' } }
+    Apple: { data: { category: 'Food', icon: ':apple:' } }
   };
   const dbmStub = {
     loadCollection: async (col) => (col === 'characters' ? charData : shopData),

--- a/tests/marketplace.test.js
+++ b/tests/marketplace.test.js
@@ -30,11 +30,10 @@ function stubModule(file, exports) {
 
   stubModule('logger.js', { debug() {}, info() {}, error() {} });
   stubModule('clientManager.js', { getEmoji: () => ':coin:' });
-  shopData = { 'Iron Sword': { infoOptions: { 'Transferrable (Y/N)': 'Yes' } } };
+  shopData = { 'Iron Sword': { data: { transferrable: 'Yes', category: 'Weapons', icon: ':sword:' } } };
   const shopStub = {
     findItemName: async name => name.toLowerCase() === 'iron sword' ? 'Iron Sword' : 'ERROR',
-    getItemCategory: async () => 'Weapons',
-    getItemIcon: async () => ':sword:'
+    getItemMetadata: async () => ({ icon: ':sword:', category: 'Weapons', transferrable: 'Yes', name: 'Iron Sword' })
   };
   stubModule('shop.js', shopStub);
 

--- a/tests/panel-category.test.js
+++ b/tests/panel-category.test.js
@@ -36,9 +36,9 @@ test('resources and ships appear only in their submenus', async () => {
     }
   };
   const shopData = {
-    Longboat: { infoOptions: { Category: 'Ships', Icon: ':ship:' } },
-    Iron: { infoOptions: { Category: 'Resources', Icon: ':iron:' } },
-    Sword: { infoOptions: { Category: 'Weapons', Icon: ':sword:' } }
+    Longboat: { data: { category: 'Ships', icon: ':ship:' } },
+    Iron: { data: { category: 'Resources', icon: ':iron:' } },
+    Sword: { data: { category: 'Weapons', icon: ':sword:' } }
   };
   const dbmStub = {
     loadCollection: async (col) => (col === 'characters' ? charData : shopData),

--- a/tests/storage-normalized.test.js
+++ b/tests/storage-normalized.test.js
@@ -34,7 +34,7 @@ test('storage uses normalized inventory when legacy storage empty', async () => 
     }
   };
   const shopData = {
-    Wood: { infoOptions: { Category: 'Resources', Icon: ':wood:' } }
+    Wood: { data: { category: 'Resources', icon: ':wood:' } }
   };
   const dbmStub = {
     loadCollection: async (col) => (col === 'characters' ? charData : shopData),


### PR DESCRIPTION
## Summary
- centralize item metadata lookups with `shop.getItemMetadata`
- store usage options inside `data` and reference via helper
- load icons and categories from `data` across panels and marketplace

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca7602e50832e94fa77becb07ad87