### PR TITLE
Use inventory view for /inventory command

### DIFF
--- a/commands/shopCommands/inventory.js
+++ b/commands/shopCommands/inventory.js
@@ -1,13 +1,17 @@
 const { SlashCommandBuilder } = require('discord.js');
-const shop = require('../../shop'); // Importing the database manager
+const { getInventoryView } = require('../../db/inventory');
 
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('inventory')
 		.setDescription('Show your inventory'),
 	async execute(interaction) {
-        const userID = interaction.user.id; // this is the actual Discord Snowflake ID
-                const [replyEmbed, rows] = await shop.createInventoryEmbed(userID, 1);
-                await interaction.reply({ embeds: [replyEmbed], components: rows });
+        const rows = await getInventoryView(interaction.user.id);
+        if (rows.length === 0) {
+                await interaction.reply({ content: 'No items in inventory!', ephemeral: true });
+                return;
+        }
+        const lines = rows.map(row => `• ${row.name} — x${row.quantity} [${row.category}]`);
+        await interaction.reply({ content: lines.join('\n'), ephemeral: true });
         },
 };

--- a/tests/inventory-command.test.js
+++ b/tests/inventory-command.test.js
@@ -12,8 +12,11 @@ function mockModule(modulePath, mock) {
 
 test('/inventory command uses user id identifier', async (t) => {
   let calledId;
-  mockModule(path.join(root, 'shop.js'), {
-    createInventoryEmbed: async (id) => { calledId = id; return [{ description: 'ok' }, []]; }
+  mockModule(path.join(root, 'db', 'inventory.js'), {
+    getInventoryView: async (id) => {
+      calledId = id;
+      return [{ name: 'Test', quantity: 1, category: 'Misc' }];
+    },
   });
   mockModule('discord.js', {
     SlashCommandBuilder: class { setName() { return this; } setDescription() { return this; } }
@@ -28,10 +31,11 @@ test('/inventory command uses user id identifier', async (t) => {
 
   await command.execute(interaction);
   assert.equal(calledId, '123456789012345678');
-  assert.ok(replied.embeds);
+  assert.equal(replied.content, '• Test — x1 [Misc]');
+  assert.equal(replied.ephemeral, true);
 
   t.after(() => {
-    delete require.cache[require.resolve(path.join(root, 'shop.js'))];
+    delete require.cache[require.resolve(path.join(root, 'db', 'inventory.js'))];
     delete require.cache[require.resolve('discord.js')];
     delete require.cache[commandPath];
   });


### PR DESCRIPTION
## Summary
- refactor /inventory command to pull rows from database view
- show inventory entries or no-inventory message as ephemeral content
- update command unit test for new data source

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb9bbef0c832e8e57d7903265ff45