### PR TITLE
Use normalized shop columns and simplify shop command

### DIFF
--- a/commands/shopCommands/shop.js
+++ b/commands/shopCommands/shop.js
@@ -1,12 +1,14 @@
-const { SlashCommandBuilder } = require('discord.js');
-const shop = require('../../shop');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { listShopItems } = require('../../db/shop');
 
 module.exports = {
-	data: new SlashCommandBuilder()
-		.setName('shop')
-		.setDescription('List shop items'),
-        async execute(interaction) {
-                const [embed, rows] = await shop.createShopEmbed();
-                await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
-        },
+  data: new SlashCommandBuilder()
+    .setName('shop')
+    .setDescription('List shop items'),
+  async execute(interaction) {
+    const items = await listShopItems();
+    const lines = items.map(i => `**${i.name}** — ${i.price == null ? 'N/A' : `${i.price} gold`}`);
+    const embed = new EmbedBuilder().setTitle('Shop Items').setDescription(lines.join('\n'));
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  },
 };

--- a/shop.js
+++ b/shop.js
@@ -276,7 +276,7 @@ class shop {
 
     const divider = '────────────────────────';
 
-    const { rows } = await db.query('SELECT id, name, item, price, data FROM shop');
+    const { rows } = await db.query('SELECT id, name, item_id, price, data FROM shop');
     const categories = {};
 
     for (const row of rows) {
@@ -339,7 +339,7 @@ class shop {
     page = Number(page);
     const itemsPerPage = 25;
 
-    const { rows } = await db.query('SELECT id, name, item, price, data FROM shop');
+    const { rows } = await db.query('SELECT id, name, item_id, price, data FROM shop');
 
     let itemCategories = {};
     for (const row of rows) {
@@ -1438,7 +1438,7 @@ static async createInventoryEmbed(charID, page = 1) {
 
   static async buyItem(shopKey, charID, numToBuy, channelId) {
     const { rows } = await db.query(
-      'SELECT item, price, data FROM shop WHERE id = $1',
+      'SELECT item_id, price, data FROM shop WHERE id = $1',
       [shopKey]
     );
     if (!rows[0]) {
@@ -1484,7 +1484,7 @@ static async createInventoryEmbed(charID, page = 1) {
       }
     }
 
-    const rawItem = row.item ?? row.data?.item_id;
+    const rawItem = row.item_id ?? row.data?.item_id ?? row.data?.item ?? row.data?.name;
     const { rows: canonRows } = await db.query('SELECT resolve_item_id($1) AS canon_id', [rawItem]);
     const canonId = canonRows[0] ? canonRows[0].canon_id : rawItem;
     const { rows: catRows } = await db.query('SELECT category FROM items WHERE id=$1', [canonId]);

--- a/tests/buy-item-inventory.test.js
+++ b/tests/buy-item-inventory.test.js
@@ -50,7 +50,7 @@ test('buyItem stores stacks in inventory_items via transaction', async () => {
         return { rows: [{ canon_id: 'Apple' }] };
       }
       if (/FROM\s+shop/i.test(text)) {
-        return { rows: [{ item: 'Apple', price: 10, data: {} }] };
+        return { rows: [{ item_id: 'Apple', price: 10, data: {} }] };
       }
       if (/FROM\s+items/i.test(text)) {
         return { rows: [{ category: 'Food' }] };

--- a/tests/buy-ship.test.js
+++ b/tests/buy-ship.test.js
@@ -39,7 +39,7 @@ test.skip('buying a ship stores it separately from inventory', async () => {
 
   const row = {
     id: 'Longboat',
-    item: 'longboat',
+    item_id: 'longboat',
     price: 10,
     data: { item_id: 'longboat', name: 'Longboat', price: 10, category: 'Ships' }
   };
@@ -95,7 +95,7 @@ test.skip('buying ship items with varied category casing routes to ships list', 
       let charData = { numericID: 'usernum', inventory: {}, ships: {} };
       const row = {
         id: 'Longboat',
-        item: 'longboat',
+        item_id: 'longboat',
         price: 10,
         data: { item_id: 'longboat', name: 'Longboat', price: 10, category }
       };

--- a/tests/inventory-view.test.js
+++ b/tests/inventory-view.test.js
@@ -48,7 +48,7 @@ const { newDb, DataType } = require('pg-mem');
   await pool.query('CREATE TABLE balances (id TEXT PRIMARY KEY, amount INTEGER DEFAULT 0)');
   await pool.query('CREATE TABLE items (id TEXT PRIMARY KEY, category TEXT, data JSONB)');
   await pool.query('CREATE TABLE inventory_items (instance_id TEXT PRIMARY KEY, owner_id TEXT, item_id TEXT, durability INTEGER, metadata JSONB)');
-  await pool.query('CREATE TABLE shop (id TEXT PRIMARY KEY, name TEXT, item TEXT, price INTEGER, data JSONB)');
+  await pool.query('CREATE TABLE shop (id TEXT PRIMARY KEY, name TEXT, item_id TEXT, price INTEGER, data JSONB)');
   await pool.query(`CREATE VIEW v_inventory AS
     SELECT ii.owner_id AS character_id,
            ii.item_id,
@@ -60,7 +60,7 @@ const { newDb, DataType } = require('pg-mem');
      GROUP BY ii.owner_id, ii.item_id, it.category`);
 
   await pool.query('INSERT INTO items (id, category, data) VALUES ($1, $2, $3)', [itemName, category, {}]);
-  await pool.query('INSERT INTO shop (id, name, item, price, data) VALUES ($1, $2, $3, $4, $5)', [itemName, itemName, itemName, 10, { channels: '', need_role: '', give_role: '' }]);
+  await pool.query('INSERT INTO shop (id, name, item_id, price, data) VALUES ($1, $2, $3, $4, $5)', [itemName, itemName, itemName, 10, { channels: '', need_role: '', give_role: '' }]);
 
   const dbmStub = {
     loadFile: async () => ({ numericID: 'usernum' }),

--- a/tests/shop-embed.test.js
+++ b/tests/shop-embed.test.js
@@ -28,7 +28,7 @@ test('createShopEmbed shows only items with numeric prices', async () => {
   const rows = [
     {
       id: 'longboat',
-      item: 'longboat',
+      item_id: 'longboat',
       name: 'Longboat',
       price: 100,
       data: {
@@ -42,7 +42,7 @@ test('createShopEmbed shows only items with numeric prices', async () => {
     },
     {
       id: 'broken_ship',
-      item: 'broken_ship',
+      item_id: 'broken_ship',
       name: 'Broken Ship',
       price: 'abc',
       data: {
@@ -55,7 +55,7 @@ test('createShopEmbed shows only items with numeric prices', async () => {
     },
     {
       id: 'wood',
-      item: 'wood',
+      item_id: 'wood',
       name: 'Wood',
       price: 5,
       data: {
@@ -69,7 +69,7 @@ test('createShopEmbed shows only items with numeric prices', async () => {
     },
     {
       id: 'stone',
-      item: 'stone',
+      item_id: 'stone',
       name: 'Stone',
       price: null,
       data: {


### PR DESCRIPTION
## Summary
- List shop items with new `shop` command using database helper
- Query normalized `item_id` and `price` columns in shop logic
- Adjust tests for normalized shop schema

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cbb2d4884832ea73e2a776ce9f810