### PR TITLE
Improve marketplace sales listing

### DIFF
--- a/commands/salesCommands/sales.js
+++ b/commands/salesCommands/sales.js
@@ -1,12 +1,16 @@
-const { SlashCommandBuilder } = require('discord.js');
-const marketplace = require('../../marketplace');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { listSales } = require('../../db/marketplace');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('sales')
         .setDescription('List sales'),
     async execute(interaction) {
-        let [embed, rows] = await marketplace.createSalesEmbed(1, interaction);
-        await interaction.reply({ embeds: [embed], components: rows});
+        const sales = await listSales();
+        const description = sales
+            .map(({ name, price }) => `• ${name} — ${price ?? 'N/A'} gold`)
+            .join('\n');
+        const embed = new EmbedBuilder().setDescription(description || 'No sales found.');
+        await interaction.reply({ embeds: [embed], ephemeral: true });
     },
 };

--- a/marketplace.js
+++ b/marketplace.js
@@ -40,10 +40,10 @@ class marketplace {
       return "You don't have enough of that item to sell it!";
     }
     charData.inventory[itemName] -= numberItems;
-    const saleData = { item_id: itemName, item: itemName, price, quantity: numberItems };
+    const saleData = { item_id: itemName, price, quantity: numberItems };
     const res = await db.query(
-      'INSERT INTO marketplace (name, data, seller, seller_id) VALUES ($1,$2,$3,$4) RETURNING id',
-      [itemName, saleData, userTag, userID]
+      'INSERT INTO marketplace (name, price, data, seller, seller_id) VALUES ($1,$2,$3,$4,$5) RETURNING id',
+      [itemName, price, saleData, userTag, userID]
     );
     const itemID = res.rows[0].id;
     await dbm.saveFile('characters', userTag, charData);
@@ -62,7 +62,7 @@ class marketplace {
     const limit = 25;
     const offset = (page - 1) * limit;
     const { rows } = await db.query(
-      "SELECT id, name, item, price, data, data->>'item_id' AS item_id FROM marketplace ORDER BY item, id LIMIT $1 OFFSET $2",
+      "SELECT id, name, price, data, data->>'item_id' AS item_id FROM marketplace ORDER BY name, id LIMIT $1 OFFSET $2",
       [limit, offset]
     );
     const countRes = await db.query('SELECT COUNT(*) FROM marketplace');
@@ -74,7 +74,7 @@ class marketplace {
 
     let descriptionText = '';
     for (const sale of rows) {
-      const itemId = sale.item_id || sale.item || sale.data?.item_id;
+      const itemId = sale.item_id ?? sale.data?.item_id;
       const quantity = Number(sale.data?.quantity ?? 0);
       const price = Number(
         sale.price ?? sale.data?.price ?? sale.data?.shopOptions?.['Price (#)'] ?? 0
@@ -123,7 +123,7 @@ class marketplace {
     const limit = 25;
     const offset = (page - 1) * limit;
     const { rows } = await db.query(
-      "SELECT id, name, item, price, data, data->>'item_id' AS item_id FROM marketplace WHERE seller=$1 ORDER BY id LIMIT $2 OFFSET $3",
+      "SELECT id, name, price, data, data->>'item_id' AS item_id FROM marketplace WHERE seller=$1 ORDER BY id LIMIT $2 OFFSET $3",
       [player, limit, offset]
     );
     const countRes = await db.query('SELECT COUNT(*) FROM marketplace WHERE seller=$1', [player]);
@@ -133,7 +133,7 @@ class marketplace {
     embed.setColor(0x36393e);
     let descriptionText = '';
     for (const sale of rows) {
-      const itemId = sale.item_id || sale.item || sale.data?.item_id;
+      const itemId = sale.item_id ?? sale.data?.item_id;
       const quantity = Number(sale.data?.quantity ?? 0);
       const price = Number(
         sale.price ?? sale.data?.price ?? sale.data?.shopOptions?.['Price (#)'] ?? 0
@@ -171,7 +171,7 @@ class marketplace {
     if (quantity < 0 || price < 0) {
       return "That sale has invalid data!";
     }
-    const itemId = sale.item_id || sale.item || sale.data?.item_id;
+    const itemId = sale.item_id ?? sale.data?.item_id;
     if (sale.seller_id == userID) {
       if (!charData[userTag].inventory[itemId]) {
         charData[userTag].inventory[itemId] = 0;
@@ -213,7 +213,7 @@ class marketplace {
     if (!sale) {
       return "That sale doesn't exist!";
     }
-    const itemId = sale.item_id || sale.item || sale.data?.item_id;
+    const itemId = sale.item_id ?? sale.data?.item_id;
     const quantity = Number(sale.data?.quantity ?? 0);
     const price = Number(
       sale.price ?? sale.data?.price ?? sale.data?.shopOptions?.['Price (#)'] ?? 0


### PR DESCRIPTION
## Summary
- Replace `/sales` command with simple ephemeral embed built from `db/marketplace.listSales`
- Normalize marketplace queries to use `name`, `item_id` and `price` fields
- Store sale price in column when posting sales and adjust tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc0b4e404832e9409e1e79a86b147