### PR TITLE
Align shop and marketplace with DB canonical items

### DIFF
--- a/commands/shopCommands/buyitem.js
+++ b/commands/shopCommands/buyitem.js
@@ -1,25 +1,88 @@
 const { SlashCommandBuilder } = require('discord.js');
-const shop = require('../../shop'); // Importing the database manager
+const { pool } = require('../../pg-client');
+
+async function findShopItem(term) {
+  const { rows } = await pool.query(`
+    SELECT id, name, item AS item_id, price
+    FROM shop
+    WHERE item = $1
+       OR name ILIKE $2
+    LIMIT 1
+  `, [term.toLowerCase(), term]);
+  return rows[0] || null;
+}
+
+async function getPlayerBalance(playerId) {
+  const { rows } = await pool.query(
+    `SELECT gold FROM balances WHERE id = $1`,
+    [playerId]
+  );
+  return rows[0]?.gold ?? 0;
+}
+
+async function buy(playerId, itemTerm, qty) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const item = await findShopItem(itemTerm);
+    if (!item) throw new Error(`Item "${itemTerm}" not found in shop.`);
+
+    const priceTotal = (item.price || 0) * (qty || 1);
+
+    const balRes = await client.query(
+      `SELECT gold FROM balances WHERE id = $1 FOR UPDATE`,
+      [playerId]
+    );
+    const currentGold = balRes.rows[0]?.gold ?? 0;
+    if (currentGold < priceTotal) {
+      throw new Error(`Not enough gold. Need ${priceTotal}, you have ${currentGold}.`);
+    }
+
+    for (let i = 0; i < qty; i++) {
+      await client.query(
+        `INSERT INTO inventory_items (instance_id, owner_id, item_id, durability, metadata)
+         VALUES (gen_random_uuid()::text, $1, $2, NULL, '{}'::jsonb)`,
+        [playerId, item.item_id]
+      );
+    }
+
+    await client.query(
+      `UPDATE balances SET gold = gold - $2 WHERE id = $1`,
+      [playerId, priceTotal]
+    );
+
+    await client.query('COMMIT');
+    return { ok: true, item, qty, priceTotal };
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
+}
 
 module.exports = {
-	data: new SlashCommandBuilder()
-		.setName('buyitem')
-		.setDescription('Buy an item')
-        .addIntegerOption((option) => 
-        option.setName('numbertobuy')
-			.setDescription('How many do you want to buy')
-			.setRequired(true)
-		)
-		.addStringOption((option) =>
-		option.setName('itemname')
-			.setDescription('The item name')
-			.setRequired(true)
-		),
-	async execute(interaction) {
-		const itemName = interaction.options.getString('itemname');
-        const numberItems = interaction.options.getInteger('numbertobuy');
-            let reply = await shop.buyItem(itemName, interaction.user.tag, numberItems, interaction.channelId)
-            interaction.reply(reply);
-			// Call the addItem function from the Shop class
-	},
+  data: new SlashCommandBuilder()
+    .setName('buyitem')
+    .setDescription('Buy an item')
+    .addStringOption(opt =>
+      opt.setName('item')
+        .setDescription('Item to buy')
+        .setRequired(true))
+    .addIntegerOption(opt =>
+      opt.setName('qty')
+        .setDescription('Quantity to buy')
+        .setRequired(false)),
+  async execute(interaction) {
+    const itemTerm = interaction.options.getString('item', true);
+    const qty = interaction.options.getInteger('qty') ?? 1;
+    const playerId = interaction.user.id;
+    try {
+      const result = await buy(playerId, itemTerm, qty);
+      await interaction.reply(`Bought ${qty} × ${result.item.name} for ${result.priceTotal} gold.`);
+    } catch (err) {
+      await interaction.reply({ content: `❌ ${err.message}`, ephemeral: true });
+    }
+  },
 };


### PR DESCRIPTION
## Summary
- Load shop listings via canonical `item` IDs and prices
- Rewrite `/buyitem` to use canonical IDs with transactional inserts
- Simplify marketplace listings to use new generated columns and update sale flows
- Adjust marketplace tests for 1-row-per-unit sales

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND at tests/storage-normalized.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689ccc816510832e83df300dc92422fb