### PR TITLE
Refactor shop queries to use item codes view

### DIFF
--- a/tests/buy-item-inventory.test.js
+++ b/tests/buy-item-inventory.test.js
@@ -46,14 +46,8 @@ test('buyItem stores stacks in inventory_items via transaction', async () => {
   const executed = [];
   const dbStub = {
     query: async (text) => {
-      if (/resolve_item_id/i.test(text)) {
-        return { rows: [{ canon_id: 'Apple' }] };
-      }
-      if (/FROM\s+shop/i.test(text)) {
-        return { rows: [{ item_id: 'Apple', price: 10, data: {} }] };
-      }
-      if (/FROM\s+items/i.test(text)) {
-        return { rows: [{ category: 'Food' }] };
+      if (/FROM\s+shop_v/i.test(text)) {
+        return { rows: [{ item_code: 'Apple', name: 'Apple', price: 10, category: 'Food' }] };
       }
       return { rows: [] };
     },

--- a/tests/buy-ship.test.js
+++ b/tests/buy-ship.test.js
@@ -37,16 +37,11 @@ test.skip('buying a ship stores it separately from inventory', async () => {
   let balance = 100;
   let charData = { numericID: 'usernum', inventory: {}, ships: {} };
 
-  const row = {
-    id: 'Longboat',
-    item_id: 'longboat',
-    price: 10,
-    data: { item_id: 'longboat', name: 'Longboat', price: 10, category: 'Ships' }
-  };
+  const row = { id: 1, item_code: 'longboat', name: 'Longboat', price: 10, category: 'Ships' };
 
   const dbStub = {
     query: async (text, params) => {
-      if (/FROM shop/i.test(text)) {
+      if (/FROM\s+shop_v/i.test(text)) {
         return { rows: [row] };
       }
       if (/resolve_item_id/i.test(text)) {
@@ -93,15 +88,10 @@ test.skip('buying ship items with varied category casing routes to ships list', 
     await t.test(category, async () => {
       let balance = 100;
       let charData = { numericID: 'usernum', inventory: {}, ships: {} };
-      const row = {
-        id: 'Longboat',
-        item_id: 'longboat',
-        price: 10,
-        data: { item_id: 'longboat', name: 'Longboat', price: 10, category }
-      };
+      const row = { id: 1, item_code: 'longboat', name: 'Longboat', price: 10, category };
       const dbStub = {
         query: async (text, params) => {
-          if (/FROM shop/i.test(text)) return { rows: [row] };
+          if (/FROM\s+shop_v/i.test(text)) return { rows: [row] };
           if (/resolve_item_id/i.test(text)) return { rows: [{ canon_id: row.data.item_id }] };
           if (/FROM items/i.test(text)) return { rows: [{ category }] };
           return { rows: [] };

--- a/tests/inventory-view.test.js
+++ b/tests/inventory-view.test.js
@@ -49,6 +49,9 @@ const { newDb, DataType } = require('pg-mem');
   await pool.query('CREATE TABLE items (id TEXT PRIMARY KEY, category TEXT, data JSONB)');
   await pool.query('CREATE TABLE inventory_items (instance_id TEXT PRIMARY KEY, owner_id TEXT, item_id TEXT, durability INTEGER, metadata JSONB)');
   await pool.query('CREATE TABLE shop (id TEXT PRIMARY KEY, name TEXT, item_id TEXT, price INTEGER, data JSONB)');
+  await pool.query(`CREATE VIEW shop_v AS
+    SELECT s.id, s.name, s.item_id AS item_code, s.price, i.category
+      FROM shop s LEFT JOIN items i ON s.item_id = i.id`);
   await pool.query(`CREATE VIEW v_inventory AS
     SELECT ii.owner_id AS character_id,
            ii.item_id,

--- a/tests/shop-embed.test.js
+++ b/tests/shop-embed.test.js
@@ -26,60 +26,10 @@ const shopPath = path.join(root, 'shop.js');
 
 test('createShopEmbed shows only items with numeric prices', async () => {
   const rows = [
-    {
-      id: 'longboat',
-      item_id: 'longboat',
-      name: 'Longboat',
-      price: 100,
-      data: {
-        item_id: 'longboat',
-        name: 'Longboat',
-        price: 100,
-        category: 'Ships',
-        icon: ':ship:',
-        description: 'A boat'
-      }
-    },
-    {
-      id: 'broken_ship',
-      item_id: 'broken_ship',
-      name: 'Broken Ship',
-      price: 'abc',
-      data: {
-        item_id: 'broken_ship',
-        name: 'Broken Ship',
-        price: 'abc',
-        category: 'Ships',
-        icon: ':ship:'
-      }
-    },
-    {
-      id: 'wood',
-      item_id: 'wood',
-      name: 'Wood',
-      price: 5,
-      data: {
-        item_id: 'wood',
-        name: 'Wood',
-        price: 5,
-        category: 'Resources',
-        icon: ':wood:',
-        description: 'Some wood'
-      }
-    },
-    {
-      id: 'stone',
-      item_id: 'stone',
-      name: 'Stone',
-      price: null,
-      data: {
-        item_id: 'stone',
-        name: 'Stone',
-        price: null,
-        category: 'Materials',
-        icon: ':rock:'
-      }
-    }
+    { id: 1, name: 'Longboat', item_code: 'longboat', price: 100, category: 'Ships' },
+    { id: 2, name: 'Broken Ship', item_code: 'broken_ship', price: 'abc', category: 'Ships' },
+    { id: 3, name: 'Wood', item_code: 'wood', price: 5, category: 'Resources' },
+    { id: 4, name: 'Stone', item_code: 'stone', price: null, category: 'Materials' }
   ];
 
   const dbStub = { query: async () => ({ rows }) };


### PR DESCRIPTION
## Summary
- query shop data from `shop_v` view and drop legacy `row.data` usage
- build shop embed from `shop_v` rows and group by category
- ensure purchases insert the `item_code` directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ceaddfe40832e8f84f4622f791535