### PR TITLE
Use marketplace view and item codes

### DIFF
--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -7,8 +7,8 @@ module.exports = {
         .setName('sell')
         .setDescription('Sell an item')
         .addStringOption((option) =>
-            option.setName('itemname')
-                .setDescription('The item name')
+            option.setName('itemcode')
+                .setDescription('The item code')
                 .setRequired(true)
         )
         .addIntegerOption((option) =>
@@ -22,10 +22,10 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-        const itemName = interaction.options.getString('itemname');
+        const itemCode = interaction.options.getString('itemcode');
         const quantity = interaction.options.getInteger('quantity');
         const price = interaction.options.getInteger('price');
-            let reply = await marketplace.postSale(quantity, itemName, price, interaction.user.tag, interaction.user.id)
+            let reply = await marketplace.postSale(quantity, itemCode, price, interaction.user.tag, interaction.user.id)
             if (typeof (reply) == 'string') {
                 await interaction.reply(reply);
             } else {

--- a/db/marketplace.js
+++ b/db/marketplace.js
@@ -2,16 +2,10 @@
 const { pool } = require('../pg-client');
 
 async function listSales() {
-  const sql = `
-    SELECT id,
-           COALESCE(NULLIF(data->>'name',''), id) AS name,
-           NULLIF(data->>'item_id','')           AS item_id,
-           NULLIF(data->>'price','')::int        AS price,
-           data
-    FROM marketplace
-    ORDER BY name NULLS LAST
-  `;
-  const { rows } = await pool.query(sql);
+  const { rows } = await pool.query(
+    'SELECT id, name, item_code, price, category FROM marketplace_v ORDER BY name'
+  );
   return rows;
 }
+
 module.exports = { listSales };


### PR DESCRIPTION
## Summary
- Query sales through new `marketplace_v` view to include `item_code`, price, and category
- Store `item_code` when posting sales and surface category/price in sale embeds
- Update sale command and tests for view-based schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf1b179b8832eb6a46bd7f51ee24a