### PR TITLE
Use item_code for marketplace listings

### DIFF
--- a/commands/salesCommands/sales.js
+++ b/commands/salesCommands/sales.js
@@ -8,7 +8,7 @@ module.exports = {
     async execute(interaction) {
         const sales = await listSales();
         const description = sales
-            .map(({ name, price }) => `• ${name} — ${price ?? 'N/A'} gold`)
+            .map(({ name, item_code, price }) => `• ${name} (${item_code}) — ${price ?? 'N/A'} gold`)
             .join('\n');
         const embed = new EmbedBuilder().setDescription(description || 'No sales found.');
         await interaction.reply({ embeds: [embed], ephemeral: true });

--- a/db/marketplace.js
+++ b/db/marketplace.js
@@ -2,9 +2,12 @@
 const { pool } = require('../pg-client');
 
 async function listSales() {
-  const { rows } = await pool.query(
-    'SELECT id, name, item_code, price, category FROM marketplace_v ORDER BY name'
-  );
+  const sql = `
+    SELECT id, name, item_code, price, category
+    FROM marketplace_v
+    ORDER BY name
+  `;
+  const { rows } = await pool.query(sql);
   return rows;
 }
 


### PR DESCRIPTION
## Summary
- query marketplace_v for sales list
- show item_code instead of item_id in `/sales`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf32e9fe4832eb36c5743ded640ee