### PR TITLE
Format sales list by category

### DIFF
--- a/commands/salesCommands/sales.js
+++ b/commands/salesCommands/sales.js
@@ -7,8 +7,9 @@ module.exports = {
         .setDescription('List sales'),
     async execute(interaction) {
         const sales = await listSales();
+        // item_code is included for use in interactive follow-ups
         const description = sales
-            .map(({ name, item_code, price }) => `• ${name} (${item_code}) — ${price ?? 'N/A'} gold`)
+            .map(({ name, item_code, price, category }) => `• ${name} — Category: ${category} — ${price ?? 'N/A'} gold`)
             .join('\n');
         const embed = new EmbedBuilder().setDescription(description || 'No sales found.');
         await interaction.reply({ embeds: [embed], ephemeral: true });

--- a/db/marketplace.js
+++ b/db/marketplace.js
@@ -3,7 +3,7 @@ const { pool } = require('../pg-client');
 
 async function listSales() {
   const sql = `
-    SELECT id, name, item_code, price, category
+    SELECT name, item_code, price, category
     FROM marketplace_v
     ORDER BY name
   `;


### PR DESCRIPTION
## Summary
- Remove id from `listSales` query and return only name, item_code, price, and category
- List sales as "• Name — Category: <category> — <price> gold" keeping item_code for interactive use

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf4bc9fd0832e94c2d7e5d171ecbb