### PR TITLE
test: stub view queries with item_code and category

### DIFF
--- a/tests/buy-item-inventory.test.js
+++ b/tests/buy-item-inventory.test.js
@@ -47,7 +47,9 @@ test('buyItem stores stacks in inventory_items via transaction', async () => {
   const dbStub = {
     query: async (text) => {
       if (/FROM\s+shop_v/i.test(text)) {
-        return { rows: [{ item_code: 'Apple', name: 'Apple', price: 10, category: 'Food' }] };
+        const result = { rows: [{ id: 1, name: 'Apple', item_code: 'Apple', price: 10, category: 'Food' }] };
+        console.log('[test] shop_v rows', result.rows);
+        return result;
       }
       return { rows: [] };
     },

--- a/tests/buy-ship.test.js
+++ b/tests/buy-ship.test.js
@@ -42,10 +42,12 @@ test.skip('buying a ship stores it separately from inventory', async () => {
   const dbStub = {
     query: async (text, params) => {
       if (/FROM\s+shop_v/i.test(text)) {
-        return { rows: [row] };
+        const result = { rows: [row] };
+        console.log('[test] shop_v rows', result.rows);
+        return result;
       }
       if (/resolve_item_id/i.test(text)) {
-        return { rows: [{ canon_id: row.data.item_id }] };
+        return { rows: [{ canon_id: row.item_code }] };
       }
       if (/FROM items/i.test(text)) {
         return { rows: [{ category: 'Ships' }] };
@@ -91,8 +93,12 @@ test.skip('buying ship items with varied category casing routes to ships list', 
       const row = { id: 1, item_code: 'longboat', name: 'Longboat', price: 10, category };
       const dbStub = {
         query: async (text, params) => {
-          if (/FROM\s+shop_v/i.test(text)) return { rows: [row] };
-          if (/resolve_item_id/i.test(text)) return { rows: [{ canon_id: row.data.item_id }] };
+          if (/FROM\s+shop_v/i.test(text)) {
+            const result = { rows: [row] };
+            console.log('[test] shop_v rows', result.rows);
+            return result;
+          }
+          if (/resolve_item_id/i.test(text)) return { rows: [{ canon_id: row.item_code }] };
           if (/FROM items/i.test(text)) return { rows: [{ category }] };
           return { rows: [] };
         },

--- a/tests/marketplace.test.js
+++ b/tests/marketplace.test.js
@@ -86,10 +86,13 @@ test('posting and buying a sale updates inventories and balances', async () => {
   // post sale
   const embed = await marketplace.postSale(2, 'iron sword', 50, 'Seller#1234', 'sellerId');
   assert.ok(embed.description.includes('listed'));
-  let { rows } = await pool.query('SELECT id, name, item_code, price FROM marketplace_v ORDER BY id');
+  let { rows } = await pool.query('SELECT id, name, item_code, price, category FROM marketplace_v ORDER BY id');
+  console.log('[test] marketplace_v rows', rows);
   assert.equal(rows.length, 2);
   assert.equal(rows[0].price, 50);
   assert.equal(rows[0].name, 'Iron Sword');
+  assert.equal(rows[0].item_code, 'Iron Sword');
+  assert.equal(rows[0].category, 'Weapons');
   assert.equal(charData['Seller#1234'].inventory['Iron Sword'], 3);
 
   // buy first sale


### PR DESCRIPTION
## Summary
- stub `shop_v` and `marketplace_v` queries to return id, name, item_code, price, category
- drop `row.data` usage in ship purchase tests
- log view rows in tests for easier debugging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf67f2f20832ea51e120bcde19dc9