### PR TITLE
feat: add DB helpers for items and inventory

### DIFF
--- a/db/inventory.js
+++ b/db/inventory.js
@@ -1,5 +1,5 @@
 // db/inventory.js
-const { pool } = require('../pg-client'); // adjust to your pool import
+const pool = require('../pg-client'); // your existing pool
 
 // 1 row per unit; name or id is OK (server resolves)
 async function grantItemToPlayer(playerId, itemIdOrName, qty = 1) {
@@ -35,8 +35,63 @@ async function getInventoryView(playerId) {
   return rows;
 }
 
+// new tiny helper to count how many of an item a user owns
+async function getCount(userId, itemCode) {
+  const { rows } = await pool.query(
+    `SELECT COUNT(*)::int AS qty
+       FROM inventory_items
+      WHERE owner_id = $1 AND item_id = $2`,
+    [userId, itemCode]
+  );
+  return rows[0]?.qty || 0;
+}
+
+// insert qty rows; caller has validated item exists
+async function give(userId, itemCode, qty = 1) {
+  const { rows } = await pool.query(
+    `INSERT INTO inventory_items (instance_id, owner_id, item_id, durability, metadata)
+     SELECT gen_random_uuid()::text, $1, $2, NULL, '{}'::jsonb
+     FROM generate_series(1, $3)
+     RETURNING 1`,
+    [userId, itemCode, qty]
+  );
+  return rows.length;
+}
+
+// delete exactly qty rows using ctid pattern (safe + fast)
+async function take(userId, itemCode, qty = 1) {
+  const { rowCount } = await pool.query(
+    `WITH victims AS (
+       SELECT ctid
+         FROM inventory_items
+        WHERE owner_id = $1 AND item_id = $2
+        LIMIT $3
+     )
+     DELETE FROM inventory_items ii
+     USING victims v
+     WHERE ii.ctid = v.ctid`,
+    [userId, itemCode, qty]
+  );
+  return rowCount; // number removed
+}
+
+async function listView(userId) {
+  const { rows } = await pool.query(
+    `SELECT item_id, quantity, name, category
+       FROM v_inventory
+      WHERE character_id = $1
+      ORDER BY name`,
+    [userId]
+  );
+  return rows;
+}
+
 module.exports = {
   grantItemToPlayer,
   takeItemsFromPlayer,
   getInventoryView,
+  getCount,
+  give,
+  take,
+  listView,
 };

--- a/db/items.js
+++ b/db/items.js
@@ -1,0 +1,20 @@
+// db/items.js
+const pool = require('../pg-client'); // your existing pool
+
+async function resolveItemCode(raw) {
+  // use DB resolver so both ids and display names work
+  const { rows } = await pool.query(
+    `SELECT resolve_item_id($1) AS item_code`, [raw]
+  );
+  return rows[0]?.item_code || raw;
+}
+
+async function getItemMetaByCode(itemCode) {
+  const { rows } = await pool.query(
+    `SELECT id AS item_code, data->>'name' AS name, data->>'category' AS category
+     FROM items WHERE id = $1`, [itemCode]
+  );
+  return rows[0] || null;
+}
+
+module.exports = { resolveItemCode, getItemMetaByCode };


### PR DESCRIPTION
## Summary
- add item lookup helpers using PostgreSQL
- expand inventory helpers for counts, give/take, and list views

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND in storage-normalized.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689d022e8918832e9553074bb0622a18