### PR TITLE
Refactor marketplace helpers to use database

### DIFF
--- a/commands/salesCommands/sales.js
+++ b/commands/salesCommands/sales.js
@@ -1,17 +1,12 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const { listSales } = require('../../db/marketplace');
+const { SlashCommandBuilder } = require('discord.js');
+const marketplace = require('../../marketplace');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('sales')
         .setDescription('List sales'),
     async execute(interaction) {
-        const sales = await listSales();
-        // item_code is included for use in interactive follow-ups
-        const description = sales
-            .map(({ name, item_code, price, category }) => `• ${name} — Category: ${category} — ${price ?? 'N/A'} gold`)
-            .join('\n');
-        const embed = new EmbedBuilder().setDescription(description || 'No sales found.');
-        await interaction.reply({ embeds: [embed], ephemeral: true });
+        const [embed, rows] = await marketplace.createSalesEmbed(1);
+        await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
     },
 };

--- a/commands/salesCommands/showsales.js
+++ b/commands/salesCommands/showsales.js
@@ -2,8 +2,6 @@
 
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const marketplace = require('../../marketplace');
-const dataGetters = require('../../dataGetters');
-const logger = require('../../logger');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -20,26 +18,13 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
-        let player = interaction.options.getUser('player');
-        let page = interaction.options.getInteger('page');
-        logger.debug(player);
-        if (!player) {
-            player = interaction.user;
-        }
-        if (!page) {
-            page = 1;
-        }
-
-        player = await dataGetters.getCharFromNumericID(player.id);
-
-        logger.debug(player);
-
-        let replyString = await marketplace.showSales(player, page);
-        //if embed, display embed, otherwise display string
-        if (typeof (replyString) == 'string') {
-            await interaction.reply(replyString);
+        const player = interaction.options.getUser('player') ?? interaction.user;
+        const page = interaction.options.getInteger('page') ?? 1;
+        const res = await marketplace.showSales(player.id, page);
+        if (typeof res === 'string') {
+            await interaction.reply(res);
         } else {
-            await interaction.reply({ embeds: [replyString] });
+            await interaction.reply({ embeds: [res] });
         }
     },
 };

--- a/marketplace.js
+++ b/marketplace.js
@@ -1,7 +1,12 @@
+const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { pool } = require('./pg-client');
 const inventory = require('./db/inventory');
 const items = require('./db/items');
+const { listSales } = require('./db/marketplace');
 
+// Create a marketplace listing for the provided item. Items are removed from the
+// seller's inventory immediately and held until the sale is purchased or
+// cancelled.
 async function postSale({ userId, rawItem, price = 0, quantity = 1 }) {
   const itemCode = await items.resolveItemCode(rawItem);
 
@@ -10,6 +15,7 @@ async function postSale({ userId, rawItem, price = 0, quantity = 1 }) {
     return { ok: false, reason: 'not_enough', owned, needed: quantity };
   }
 
+  // remove the items from the seller
   const removed = await inventory.take(userId, itemCode, quantity);
   if (removed !== quantity) {
     return { ok: false, reason: 'concurrent_change' };
@@ -26,12 +32,151 @@ async function postSale({ userId, rawItem, price = 0, quantity = 1 }) {
   return { ok: true, itemCode, price, quantity };
 }
 
-async function listSales() {
-  const { rows } = await pool.query(
-    'SELECT name, item_code, price, category FROM marketplace_v ORDER BY name'
-  );
-  return rows;
+// ---------------------------------------------------------------------------
+// Listing helpers
+// ---------------------------------------------------------------------------
+
+// Render a paginated list of all sales on the marketplace. Returns an embed and
+// an array of ActionRows for navigation buttons.
+async function createSalesEmbed(page = 1) {
+  const sales = await listSales();
+  const perPage = 10;
+  const totalPages = Math.max(1, Math.ceil(sales.length / perPage));
+  const curPage = Math.min(Math.max(1, Number(page) || 1), totalPages);
+  const slice = sales.slice((curPage - 1) * perPage, curPage * perPage);
+
+  const description = slice
+    .map(({ name, price, category }) =>
+      `• ${name} — Category: ${category} — ${price ?? 'N/A'} gold`
+    )
+    .join('\n');
+
+  const embed = new EmbedBuilder()
+    .setTitle('Marketplace Listings')
+    .setDescription(description || 'No sales found.')
+    .setFooter({ text: `Page ${curPage} of ${totalPages}` });
+
+  const rows = [];
+  if (totalPages > 1) {
+    const row = new ActionRowBuilder();
+    if (curPage > 1) {
+      row.addComponents(
+        new ButtonBuilder()
+          .setCustomId(`salesSwitch${curPage - 1}`)
+          .setLabel('Prev')
+          .setStyle(ButtonStyle.Primary)
+      );
+    }
+    if (curPage < totalPages) {
+      row.addComponents(
+        new ButtonBuilder()
+          .setCustomId(`salesSwitch${curPage + 1}`)
+          .setLabel('Next')
+          .setStyle(ButtonStyle.Primary)
+      );
+    }
+    rows.push(row);
+  }
+
+  return [embed, rows];
 }
 
-module.exports = { postSale, listSales };
+// Show the sales for a specific user. Returns an Embed or a string if none.
+async function showSales(userId, page = 1) {
+  const { rows } = await pool.query(
+    'SELECT id, name, price, quantity FROM marketplace WHERE seller = $1 ORDER BY name',
+    [userId]
+  );
+
+  if (rows.length === 0) return 'No sales found.';
+
+  const perPage = 10;
+  const totalPages = Math.max(1, Math.ceil(rows.length / perPage));
+  const curPage = Math.min(Math.max(1, Number(page) || 1), totalPages);
+  const slice = rows.slice((curPage - 1) * perPage, curPage * perPage);
+
+  const description = slice
+    .map(({ id, name, price, quantity }) =>
+      `ID: ${id} — ${quantity}× ${name} — ${price} gold each`
+    )
+    .join('\n');
+
+  const embed = new EmbedBuilder()
+    .setTitle('Player Sales')
+    .setDescription(description)
+    .setFooter({ text: `Page ${curPage} of ${totalPages}` });
+
+  return embed;
+}
+
+// Display details of a single sale by ID.
+async function inspectSale(saleId) {
+  const { rows } = await pool.query(
+    'SELECT id, name, price, quantity, seller FROM marketplace WHERE id = $1',
+    [saleId]
+  );
+  if (!rows[0]) return 'Sale not found.';
+  const sale = rows[0];
+  const embed = new EmbedBuilder()
+    .setTitle(`Sale ${sale.id}`)
+    .setDescription(
+      `${sale.quantity}× ${sale.name}\nPrice: ${sale.price} gold each\nSeller: <@${sale.seller}>`
+    );
+  return embed;
+}
+
+// Purchase a sale and transfer items and gold appropriately.
+async function buySale(saleId, buyerTag, buyerId) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const { rows } = await client.query(
+      'SELECT id, name, price, quantity, seller, item_code FROM marketplace WHERE id = $1 FOR UPDATE',
+      [saleId]
+    );
+    if (!rows[0]) {
+      await client.query('ROLLBACK');
+      return 'Sale not found.';
+    }
+    const sale = rows[0];
+    const totalPrice = sale.price * sale.quantity;
+
+    const balRes = await client.query(
+      'SELECT amount FROM balances WHERE id = $1 FOR UPDATE',
+      [buyerId]
+    );
+    const balance = balRes.rows[0]?.amount ?? 0;
+    if (balance < totalPrice) {
+      await client.query('ROLLBACK');
+      return 'Insufficient funds.';
+    }
+
+    await client.query('UPDATE balances SET amount = amount - $2 WHERE id = $1', [buyerId, totalPrice]);
+    await client.query(
+      'INSERT INTO balances (id, amount) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET amount = balances.amount + EXCLUDED.amount',
+      [sale.seller, totalPrice]
+    );
+
+    await inventory.give(buyerId, sale.item_code, sale.quantity);
+    await client.query('DELETE FROM marketplace WHERE id = $1', [saleId]);
+
+    await client.query('COMMIT');
+    return `${buyerTag} bought ${sale.quantity}× ${sale.name} for ${totalPrice} gold.`;
+  } catch (err) {
+    try { await client.query('ROLLBACK'); } catch {}
+    return 'Failed to buy sale.';
+  } finally {
+    client.release();
+  }
+}
+
+module.exports = {
+  postSale,
+  listSales,
+  createSalesEmbed,
+  showSales,
+  inspectSale,
+  buySale,
+};
 


### PR DESCRIPTION
## Summary
- add DB-backed helpers for listing, inspecting and buying marketplace sales
- rework `/sales` and `/showsales` commands to use new helpers
- handle sale purchases with inventory and balance updates in SQL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d09eee2d0832eb18e2725e3b1116b