### PR TITLE
Use currency emoji in sell command confirmation

### DIFF
--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const marketplace = require('../../marketplace');
 const items = require('../../db/items');
+const clientManager = require('../../clientManager');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -44,6 +45,7 @@ module.exports = {
             return;
         }
 
-        await interaction.reply(`Listed ${qty} × ${res.itemCode} for ${price} each on the marketplace. Sale ID: ${res.saleId}`);
+        const emoji = clientManager.getEmoji('Gold') ?? '';
+        await interaction.reply(`Listed ${qty} × ${res.itemCode} for ${emoji}${price} each on the marketplace.`);
     }
 };


### PR DESCRIPTION
## Summary
- use clientManager to pull the Gold emoji for marketplace listings
- format sell confirmation with currency emoji and remove sale ID
- restore config helper accidentally deleted during development

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d128aa0ec832e903189cdd43ce4ed