### PR TITLE
feat: add pagination for marketplace listings

### DIFF
--- a/commands/salesCommands/sales.js
+++ b/commands/salesCommands/sales.js
@@ -4,9 +4,15 @@ const { createSalesEmbed } = require('../../marketplace');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('sales')
-        .setDescription('List sales'),
+        .setDescription('List sales')
+        .addIntegerOption(option =>
+            option.setName('page')
+                .setDescription('Page number')
+                .setRequired(false)
+        ),
     async execute(interaction) {
-        const [embed, rows] = await createSalesEmbed(1);
+        const page = interaction.options.getInteger('page') ?? 1;
+        const [embed, rows] = await createSalesEmbed(page);
         await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
     },
 };

--- a/db/marketplace.js
+++ b/db/marketplace.js
@@ -1,14 +1,41 @@
 // db/marketplace.js
 const { pool } = require('../pg-client');
 
-async function listSales() {
-  const sql = `
-    SELECT name, item_code, price, category
+async function listSales({ sellerId, limit, offset, cursor } = {}) {
+  const conditions = [];
+  const params = [];
+  if (sellerId) {
+    params.push(sellerId);
+    conditions.push(`seller = $${params.length}`);
+  }
+  if (cursor) {
+    params.push(cursor);
+    conditions.push(`id > $${params.length}`);
+  }
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  let sql = `
+    SELECT id, name, item_code, price, quantity, seller, category
     FROM marketplace_v
-    ORDER BY name
+    ${where}
+    ORDER BY ${cursor ? 'id' : 'name'}
   `;
-  const { rows } = await pool.query(sql);
-  return rows;
+  if (limit !== undefined) {
+    params.push(limit);
+    sql += ` LIMIT $${params.length}`;
+  }
+  if (offset !== undefined) {
+    params.push(offset);
+    sql += ` OFFSET $${params.length}`;
+  }
+  const { rows } = await pool.query(sql, params);
+  let totalCount;
+  if (limit !== undefined || offset !== undefined) {
+    const countSql = `SELECT COUNT(*) FROM marketplace_v ${where}`;
+    const countParams = params.slice(0, conditions.length);
+    const countRes = await pool.query(countSql, countParams);
+    totalCount = Number(countRes.rows[0].count);
+  }
+  return { rows, totalCount };
 }
 
 module.exports = { listSales };


### PR DESCRIPTION
## Summary
- add pagination options to marketplace sale queries
- paginate sales embeds and showSales output
- allow sales command to specify start page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d15479a40832e8c5c68162c251c09