### PR TITLE
Clarify sell command options and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ Use `/panel` to open a personal control panel. The response is ephemeral and vis
 
 Inventory, resource storage, and ship views support pagination. Use the `<` and `>` buttons to move between pages.
 
+## /sell command
+
+Use `/sell` to list an inventory item for sale on the marketplace. Provide an item code or name (item codes avoid ambiguity). Quantity defaults to 1 and price defaults to 0.
+

--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -6,19 +6,19 @@ const clientManager = require('../../clientManager');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('sell')
-        .setDescription('Sell an item (use item codes to avoid ambiguity)')
+        .setDescription('List an inventory item for sale')
         .addStringOption((option) =>
             option.setName('item')
-                .setDescription('The item code (names may be ambiguous)')
+                .setDescription('Item code or name (codes avoid ambiguity)')
                 .setRequired(true)
         )
         .addIntegerOption((option) =>
             option.setName('quantity')
-                .setDescription('The quantity of the item')
+                .setDescription('Quantity of the item (defaults to 1)')
         )
         .addIntegerOption((option) =>
             option.setName('price')
-                .setDescription('The price of the item')
+                .setDescription('Price per item (defaults to 0)')
         ),
     async execute(interaction) {
         const userId = interaction.user.id;


### PR DESCRIPTION
## Summary
- Clarify `/sell` description to indicate it lists an inventory item for sale
- Explain item code vs. name and mention quantity and price defaults
- Document `/sell` command in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d17f163b0832eba451043f96d5d78