### PR TITLE
Require character record before selling items

### DIFF
--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const { postSale } = require('../../marketplace');
 const items = require('../../db/items');
 const clientManager = require('../../clientManager');
+const dbm = require('../../database-manager');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -22,6 +23,12 @@ module.exports = {
         ),
     async execute(interaction) {
         const userId = interaction.user.id;
+        const charData = await dbm.loadFile('characters', userId);
+        if (!charData) {
+            await interaction.reply({ content: "You haven't made a character! Use /newchar first", ephemeral: true });
+            return;
+        }
+
         const rawItem = interaction.options.getString('item');
         const price = interaction.options.getInteger('price') ?? 0;
         const qty = interaction.options.getInteger('quantity') ?? 1;

--- a/tests/sell-command.test.js
+++ b/tests/sell-command.test.js
@@ -1,0 +1,68 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+const commandPath = path.join(root, 'commands', 'salesCommands', 'sell.js');
+
+function mockModule(modulePath, mock) {
+  const resolved = require.resolve(modulePath);
+  require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports: mock };
+}
+
+test('/sell requires existing character', async (t) => {
+  let postCalled = false;
+  mockModule(path.join(root, 'database-manager.js'), {
+    loadFile: async () => undefined,
+  });
+  mockModule(path.join(root, 'marketplace.js'), {
+    postSale: async () => { postCalled = true; },
+  });
+  mockModule(path.join(root, 'db', 'items.js'), {
+    resolveItemCode: async () => 'sword',
+  });
+  mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => '' });
+  mockModule('discord.js', {
+    SlashCommandBuilder: class {
+      setName() { return this; }
+      setDescription() { return this; }
+      addStringOption(fn) {
+        fn({
+          setName() { return this; },
+          setDescription() { return this; },
+          setRequired() { return this; }
+        });
+        return this;
+      }
+      addIntegerOption(fn) {
+        fn({ setName() { return this; }, setDescription() { return this; } });
+        return this;
+      }
+    }
+  });
+
+  const command = require(commandPath);
+  let replyPayload;
+  const interaction = {
+    user: { id: 'userX' },
+    reply: async (payload) => { replyPayload = payload; }
+  };
+
+  await command.execute(interaction);
+
+  assert.equal(postCalled, false);
+  assert.deepEqual(replyPayload, {
+    content: "You haven't made a character! Use /newchar first",
+    ephemeral: true,
+  });
+
+  t.after(() => {
+    delete require.cache[require.resolve(path.join(root, 'database-manager.js'))];
+    delete require.cache[require.resolve(path.join(root, 'marketplace.js'))];
+    delete require.cache[require.resolve(path.join(root, 'db', 'items.js'))];
+    delete require.cache[require.resolve(path.join(root, 'clientManager.js'))];
+    delete require.cache[require.resolve('discord.js')];
+    delete require.cache[commandPath];
+  });
+});
+


### PR DESCRIPTION
## Summary
- Check for a player's character record before executing `/sell`
- Guide users without a character to create one
- Add test ensuring `/sell` rejects users without characters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d190c3414832ebcb9ee50a4c555fe