### PR TITLE
Refactor sales command to build embeds from marketplace data

### DIFF
--- a/commands/salesCommands/sales.js
+++ b/commands/salesCommands/sales.js
@@ -1,5 +1,11 @@
-const { SlashCommandBuilder } = require('discord.js');
-const { createSalesEmbed } = require('../../marketplace');
+const {
+  SlashCommandBuilder,
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} = require('discord.js');
+const marketplace = require('../../marketplace');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -11,8 +17,52 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
-        const page = interaction.options.getInteger('page') ?? 1;
-        const [embed, rows] = await createSalesEmbed(page);
+        const perPage = 10;
+        let page = interaction.options.getInteger('page') ?? 1;
+        page = Math.max(1, Number(page) || 1);
+        let offset = (page - 1) * perPage;
+
+        let { rows: sales, totalCount } = await marketplace.listSales({ limit: perPage, offset });
+        const totalPages = Math.max(1, Math.ceil(totalCount / perPage));
+        if (page > totalPages) {
+            page = totalPages;
+            offset = (page - 1) * perPage;
+            ({ rows: sales } = await marketplace.listSales({ limit: perPage, offset }));
+        }
+
+        const description = sales
+            .map(({ name, item_code, price, category }) =>
+                `• ${name} (${item_code}) — Category: ${category} — ${price ?? 'N/A'} gold`
+            )
+            .join('\n');
+
+        const embed = new EmbedBuilder()
+            .setTitle('Marketplace Listings')
+            .setDescription(description || 'No sales found.')
+            .setFooter({ text: `Page ${page} of ${totalPages}` });
+
+        const rows = [];
+        if (totalPages > 1) {
+            const row = new ActionRowBuilder();
+            if (page > 1) {
+                row.addComponents(
+                    new ButtonBuilder()
+                        .setCustomId(`salesSwitch${page - 1}`)
+                        .setLabel('Prev')
+                        .setStyle(ButtonStyle.Primary)
+                );
+            }
+            if (page < totalPages) {
+                row.addComponents(
+                    new ButtonBuilder()
+                        .setCustomId(`salesSwitch${page + 1}`)
+                        .setLabel('Next')
+                        .setStyle(ButtonStyle.Primary)
+                );
+            }
+            rows.push(row);
+        }
+
         await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
     },
 };


### PR DESCRIPTION
## Summary
- Build `/sales` embeds by querying `marketplace.listSales` with page-based pagination
- Render listings using only name, item code, price, and category and include navigation buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1d0efb94832e874040d40454829c