### PR TITLE
Use DB-backed character and shop lookups

### DIFF
--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const { postSale } = require('../../marketplace');
 const items = require('../../db/items');
 const clientManager = require('../../clientManager');
-const dbm = require('../../database-manager');
+const db = require('../../pg-client');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -23,8 +23,8 @@ module.exports = {
         ),
     async execute(interaction) {
         const userId = interaction.user.id;
-        const charData = await dbm.loadFile('characters', userId);
-        if (!charData) {
+        const { rowCount } = await db.query('SELECT 1 FROM characters WHERE id = $1', [userId]);
+        if (rowCount === 0) {
             await interaction.reply({ content: "You haven't made a character! Use /newchar first", ephemeral: true });
             return;
         }

--- a/tests/buy-item-inventory.test.js
+++ b/tests/buy-item-inventory.test.js
@@ -67,6 +67,7 @@ test('buyItem stores stacks in inventory_items via transaction', async () => {
   const shopModule = await mockImport(shopPath, {
     './database-manager': dbmStub,
     './pg-client': dbStub,
+    './db/items': { getItemMetaByCode: async code => ({ item_code: code, name: code }) },
     './clientManager': { getUser: async () => ({ roles: { cache: { some: () => false }, add: () => {} } }) },
     './logger': { debug() {}, info() {}, error() {} },
     './char': { addShip: () => {} }

--- a/tests/dataGetters.test.js
+++ b/tests/dataGetters.test.js
@@ -3,7 +3,6 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 const rootDir = path.resolve(__dirname, '..');
-const dbmPath = path.join(rootDir, 'database-manager.js');
 const dataGettersPath = path.join(rootDir, 'dataGetters.js');
 const pgClientPath = path.join(rootDir, 'pg-client.js');
 const loggerPath = path.join(rootDir, 'logger.js');
@@ -33,11 +32,9 @@ let pool;
   };
 })();
 
-const dbm = require(dbmPath);
 const dataGetters = require(dataGettersPath);
 
 after(() => {
-  delete require.cache[dbmPath];
   delete require.cache[dataGettersPath];
   delete require.cache[pgClientPath];
   delete require.cache[loggerPath];
@@ -45,8 +42,8 @@ after(() => {
 });
 
 test('getCharFromNumericID retrieves matching character', async () => {
-  await dbm.saveFile('characters', 'UserOne#0001', { numericID: 101 });
-  await dbm.saveFile('characters', 'UserTwo#0002', { numericID: 202 });
+  await pool.query('INSERT INTO characters (id, data) VALUES ($1, $2)', ['UserOne#0001', { numericID: 101 }]);
+  await pool.query('INSERT INTO characters (id, data) VALUES ($1, $2)', ['UserTwo#0002', { numericID: 202 }]);
 
   assert.equal(await dataGetters.getCharFromNumericID(202), 'UserTwo#0002');
   assert.equal(await dataGetters.getCharFromNumericID(999), 'ERROR');

--- a/tests/inventory-view.test.js
+++ b/tests/inventory-view.test.js
@@ -93,6 +93,7 @@ const { newDb, DataType } = require('pg-mem');
   const shopModule = await mockImport(shopPath, {
     './database-manager': dbmStub,
     './pg-client': dbStub,
+    './db/items': { getItemMetaByCode: async code => ({ item_code: code, name: code }) },
     './clientManager': { getUser: async () => ({ roles: { cache: { some: () => false }, add: () => {} } }) },
     './logger': { debug() {}, info() {}, error() {} },
     './char': { addShip: () => {} }

--- a/tests/sell-command.test.js
+++ b/tests/sell-command.test.js
@@ -12,8 +12,8 @@ function mockModule(modulePath, mock) {
 
 test('/sell requires existing character', async (t) => {
   let postCalled = false;
-  mockModule(path.join(root, 'database-manager.js'), {
-    loadFile: async () => undefined,
+  mockModule(path.join(root, 'pg-client.js'), {
+    query: async () => ({ rows: [], rowCount: 0 })
   });
   mockModule(path.join(root, 'marketplace.js'), {
     postSale: async () => { postCalled = true; },
@@ -57,10 +57,10 @@ test('/sell requires existing character', async (t) => {
   });
 
   t.after(() => {
-    delete require.cache[require.resolve(path.join(root, 'database-manager.js'))];
     delete require.cache[require.resolve(path.join(root, 'marketplace.js'))];
     delete require.cache[require.resolve(path.join(root, 'db', 'items.js'))];
     delete require.cache[require.resolve(path.join(root, 'clientManager.js'))];
+    delete require.cache[require.resolve(path.join(root, 'pg-client.js'))];
     delete require.cache[require.resolve('discord.js')];
     delete require.cache[commandPath];
   });

--- a/tests/shop-embed.test.js
+++ b/tests/shop-embed.test.js
@@ -49,6 +49,7 @@ test('createShopEmbed shows only items with numeric prices', async () => {
     './database-manager': {},
     './clientManager': {},
     './dataGetters': {},
+    './db/items': { getItemMetaByCode: async code => ({ item_code: code, name: code }) },
     './logger': { debug() {}, info() {}, error() {} }
   });
 


### PR DESCRIPTION
## Summary
- Query characters table directly in /sell command instead of using database-manager
- Use SQL lookups in dataGetters to resolve character IDs by numeric ID
- Load shop items via db/items metadata and shop_v view in buyItem

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dbcee9f08832e91e147ff18baaa40