### PR TITLE
Use DB query for editingFields

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -344,13 +344,13 @@ When selected grants the:
   
     mapData = mapData[mapName];
   
-    let userData = await dbm.loadFile('characters', tag);
-    if (!userData.editingFields) {
-      userData.editingFields = {};
+    let editingFields = await dbm.getEditingFields(tag);
+    if (!editingFields) {
+      editingFields = {};
     }
-    userData.editingFields["Map Edited"] = mapName;
-    userData.editingFields["Map Type Edited"] = mapType;
-    await dbm.saveFile('characters', tag, userData);
+    editingFields["Map Edited"] = mapName;
+    editingFields["Map Type Edited"] = mapType;
+    await dbm.setEditingFields(tag, editingFields);
   
     // Construct the edit menu embed
     const embed = new EmbedBuilder()
@@ -415,13 +415,13 @@ When selected grants the:
   
   static async editMapField(charTag, field, value) {
     // Load the maps collection
-    let charData = await dbm.loadFile('characters', charTag);
-    if (!charData.editingFields || !charData.editingFields["Map Edited"] || !charData.editingFields["Map Type Edited"]) {
+    let editingFields = await dbm.getEditingFields(charTag);
+    if (!editingFields || !editingFields["Map Edited"] || !editingFields["Map Type Edited"]) {
       return "You must use /editmapmenu first to select a map to edit";
     }
-    let data = await dbm.loadFile('keys', charData.editingFields["Map Type Edited"] + 's');
-    let mapName = charData.editingFields["Map Edited"];
-    let mapType = charData.editingFields["Map Type Edited"];
+    let data = await dbm.loadFile('keys', editingFields["Map Type Edited"] + 's');
+    let mapName = editingFields["Map Edited"];
+    let mapType = editingFields["Map Type Edited"];
     if (data[mapName] == undefined) {
       return "Map not found! Must match the exact name of the map, case sensitive."
     }
@@ -1158,20 +1158,19 @@ When selected grants the:
         "\n`[7] Income Delay: ` " + delayString
       );
 
-    let userData = await dbm.loadFile("characters", charTag);
-    if (!userData.editingFields) {
-      userData.editingFields = {};
+    let editingFields = await dbm.getEditingFields(charTag);
+    if (!editingFields) {
+      editingFields = {};
     }
-    userData.editingFields["Income Edited"] = income;
-    await dbm.saveFile("characters", charTag, userData);
+    editingFields["Income Edited"] = income;
+    await dbm.setEditingFields(charTag, editingFields);
 
     return returnEmbed;
   }
 
   static async editIncomeField(fieldNumber, charTag, newValue) {
-    let userData = await dbm.loadFile("characters", charTag)
-    let editingFields = userData.editingFields;
-    let income = editingFields["Income Edited"];
+    let editingFields = await dbm.getEditingFields(charTag);
+    let income = editingFields ? editingFields["Income Edited"] : undefined;
     let incomeList = await dbm.loadFile("keys", "incomeList");
     let incomeValue = incomeList[income];
     let shopData = await dbm.loadCollection("shop");

--- a/commands/adminCommands/editembedaboutmodal.js
+++ b/commands/adminCommands/editembedaboutmodal.js
@@ -11,11 +11,10 @@ module.exports = {
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
         try {
-            let mapName = await dbm.loadFile('characters', interaction.user.tag);   
-            
-            mapName = mapName.editingFields["Map Edited"];
-            let mapTypeEdited = mapName.editingFields["Map Type Edited"];
-            
+            let editingFields = await dbm.getEditingFields(interaction.user.tag);
+            let mapName = editingFields["Map Edited"];
+            let mapTypeEdited = editingFields["Map Type Edited"];
+
             let maps = await dbm.loadFile('keys', mapTypeEdited);
 
             let mapAbout = maps[mapName].mapOptions.about;

--- a/database-manager.js
+++ b/database-manager.js
@@ -170,6 +170,22 @@ async function findCharacterByNumericID(numericID) {
   return res.rows[0] ? res.rows[0].id : undefined;
 }
 
+async function getEditingFields(id) {
+  const res = await db.query(
+    "SELECT data->'editingFields' AS editingFields FROM characters WHERE id=$1",
+    [id]
+  );
+  return res.rows[0] ? res.rows[0].editingfields : undefined;
+}
+
+async function setEditingFields(id, editingFields) {
+  await db.query(
+    `INSERT INTO characters (id, data) VALUES ($1, jsonb_build_object('editingFields', $2::jsonb))
+     ON CONFLICT (id) DO UPDATE SET data = jsonb_set(COALESCE(characters.data, '{}'::jsonb), '{editingFields}', $2::jsonb)`,
+    [id, editingFields]
+  );
+}
+
 async function seedTableIfEmpty(table, filePath) {
   const countRes = await db.query(`SELECT COUNT(*) FROM ${table}`);
   if (Number(countRes.rows[0].count) === 0) {
@@ -317,6 +333,8 @@ module.exports = {
   loadCollectionFileNames,
   saveFile,
   loadFile,
+  getEditingFields,
+  setEditingFields,
   findCharacterByNumericID,
   docDelete,
   fieldDelete,


### PR DESCRIPTION
## Summary
- Add helpers to query and update `editingFields` in the `characters` table
- Use DB-backed editing fields for map and income editing flows
- Fix admin modal to read `editingFields` from DB before loading maps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dc6b90034832eb42c33b7cce24165