### PR TITLE
Use test helpers to seed character data

### DIFF
--- a/test-helpers.cjs
+++ b/test-helpers.cjs
@@ -1,0 +1,15 @@
+async function insertCharacters(client, chars) {
+  const ids = [];
+  for (const { id, data } of chars) {
+    await client.query('INSERT INTO characters (id, data) VALUES ($1, $2)', [id, data]);
+    ids.push(id);
+  }
+  return ids;
+}
+
+async function cleanupCharacters(client, ids) {
+  if (!ids.length) return;
+  await client.query('DELETE FROM characters WHERE id = ANY($1::text[])', [ids]);
+}
+
+module.exports = { insertCharacters, cleanupCharacters };


### PR DESCRIPTION
## Summary
- Add `test-helpers.cjs` to insert and clean up character rows in tests
- Refactor `dataGetters.test.js` to seed characters via INSERTs and clean up afterward

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dc9eeffcc832e9bddb907e1f697ba