### PR TITLE
Handle missing execute in command interaction

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -95,6 +95,12 @@ client.once('ready', () => {
 client.on(Events.InteractionCreate, async interaction => {
   if (interaction.isChatInputCommand()) {
     const command = client.commands.get(interaction.commandName);
+    if (!command || typeof command.execute !== 'function') {
+      console.warn(`[warn] command ${interaction.commandName} missing execute()`);
+      return interaction
+        .reply({ ephemeral: true, content: "Sorry, that command isn't available right now." })
+        .catch(() => {});
+    }
     try {
       await command.execute(interaction);
     } catch (err) {


### PR DESCRIPTION
## Summary
- guard command interaction to ensure execute function exists

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND, 26 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689e364156e0832ea69be88792354702