### PR TITLE
refactor: accept resolved item code in postSale

### DIFF
--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -37,7 +37,7 @@ module.exports = {
             return;
         }
 
-        const res = await postSale({ userId: charId, rawItem: itemCode, price, quantity: qty });
+        const res = await postSale({ userId: charId, itemCode, price, quantity: qty });
 
         if (!res.ok) {
             if (res.reason === 'not_enough') {

--- a/marketplace.js
+++ b/marketplace.js
@@ -8,8 +8,10 @@ const logger = require('./logger');
 // Create a marketplace listing for the provided item. Items are removed from the
 // seller's inventory immediately and held until the sale is purchased or
 // cancelled.
-async function postSale({ userId, rawItem, price = 0, quantity = 1 }) {
-  const itemCode = await items.resolveItemCode(rawItem);
+//
+// `itemCode` must already be resolved to a valid item identifier before calling
+// this function.
+async function postSale({ userId, itemCode, price = 0, quantity = 1 }) {
 
   const owned = await inventory.getCount(userId, itemCode);
   if (owned < quantity) {

--- a/tests/marketplace.test.js
+++ b/tests/marketplace.test.js
@@ -65,7 +65,7 @@ test('postSale handles inventory operations correctly', async () => {
   // success path
   inventory._setGetCount(async () => 5);
   inventory._setTake(async (_u, _i, qty) => qty);
-  let res = await postSale({ userId: 'user1', rawItem: 'sword', price: 10, quantity: 2 });
+  let res = await postSale({ userId: 'user1', itemCode: 'sword', price: 10, quantity: 2 });
   assert.equal(res.ok, true);
   assert.equal(res.itemCode, 'sword');
   assert.equal(res.price, 10);
@@ -77,7 +77,7 @@ test('postSale handles inventory operations correctly', async () => {
   // not enough items
   inventory._setGetCount(async () => 1);
   inventory._setTake(async () => { throw new Error('should not be called'); });
-  res = await postSale({ userId: 'user1', rawItem: 'sword', price: 10, quantity: 5 });
+  res = await postSale({ userId: 'user1', itemCode: 'sword', price: 10, quantity: 5 });
   assert.deepEqual(res, { ok: false, reason: 'not_enough', owned: 1, needed: 5 });
   ;({ rows } = await pool.query('SELECT * FROM marketplace'));
   assert.equal(rows.length, 1); // no new row
@@ -85,7 +85,7 @@ test('postSale handles inventory operations correctly', async () => {
   // concurrent change during take
   inventory._setGetCount(async () => 5);
   inventory._setTake(async (_u, _i, qty) => qty - 1);
-  res = await postSale({ userId: 'user1', rawItem: 'sword', price: 10, quantity: 3 });
+  res = await postSale({ userId: 'user1', itemCode: 'sword', price: 10, quantity: 3 });
   assert.deepEqual(res, { ok: false, reason: 'concurrent_change' });
   ;({ rows } = await pool.query('SELECT * FROM marketplace'));
   assert.equal(rows.length, 1); // still only the first successful sale

--- a/tests/sell-command.test.js
+++ b/tests/sell-command.test.js
@@ -22,7 +22,7 @@ test('/sell lists item and ensures character', async (t) => {
   mockModule(path.join(root, 'marketplace.js'), {
     postSale: async (args) => {
       postArgs = args;
-      return { ok: true, itemCode: args.rawItem, price: args.price, quantity: args.quantity };
+      return { ok: true, itemCode: args.itemCode, price: args.price, quantity: args.quantity };
     },
   });
   mockModule(path.join(root, 'db', 'items.js'), {
@@ -62,7 +62,7 @@ test('/sell lists item and ensures character', async (t) => {
   await command.execute(interaction);
 
   assert.equal(ensureCalled, true);
-  assert.deepEqual(postArgs, { userId: 'charX', rawItem: 'sword', price: 0, quantity: 1 });
+  assert.deepEqual(postArgs, { userId: 'charX', itemCode: 'sword', price: 0, quantity: 1 });
   assert.equal(replyPayload, 'Listed 1 × sword for 0 each on the marketplace.');
 
   t.after(() => {


### PR DESCRIPTION
## Summary
- update `marketplace.postSale` to require a pre-resolved `itemCode`
- adjust `/sell` command to pass `itemCode`
- update tests for new `itemCode` parameter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e436284c4832eaa26c9b215ffb29c