### PR TITLE
Simplify shop balance and inventory handling

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -4,20 +4,7 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('
 const dataGetters = require('./dataGetters');
 const logger = require('./logger');
 const items = require('./db/items');
-
-let inventoryModule;
-try {
-  inventoryModule = require('./db/inventory');
-} catch (err) {
-  inventoryModule = null;
-}
-
-let dbm;
-try {
-  dbm = require('./database-manager');
-} catch (err) {
-  dbm = null;
-}
+const inventoryModule = require('./db/inventory');
 
 async function fetchShopItems() {
   const { rows } = await db.query(
@@ -363,16 +350,11 @@ class shop {
       return 'Not a valid item to purchase!';
     }
 
-    let currentBalance;
-    if (dbm && dbm.getBalance) {
-      currentBalance = await dbm.getBalance(charID);
-    } else {
-      const { rows: balRows } = await db.query(
-        'SELECT amount FROM balances WHERE id=$1',
-        [charID]
-      );
-      currentBalance = balRows[0]?.amount || 0;
-    }
+    const { rows: balRows } = await db.query(
+      'SELECT amount FROM balances WHERE id=$1',
+      [charID]
+    );
+    const currentBalance = balRows[0]?.amount || 0;
     const totalCost = price * numToBuy;
     if (currentBalance < totalCost) {
       return 'You do not have enough gold!';
@@ -380,11 +362,7 @@ class shop {
 
     const itemCode = meta.item_code;
     try {
-      if (inventoryModule) {
-        await inventoryModule.getCount(charID, itemCode);
-      } else {
-        await db.query('SELECT COUNT(*) FROM inventory_items WHERE owner_id=$1 AND item_id=$2', [charID, itemCode]);
-      }
+      await inventoryModule.getCount(charID, itemCode);
     } catch (err) {
       logger.error(err);
     }

--- a/tests/create-category-embed.test.js
+++ b/tests/create-category-embed.test.js
@@ -30,16 +30,10 @@ function mockModule(modulePath, mock) {
 test('createCategoryEmbed shows items for category', async () => {
   delete require.cache[require.resolve(shopPath)];
 
-  const charData = { 'Player#0001': { numericID: 'player1' } };
-  const shopData = { Wood: { data: { category: 'Resources', icon: ':wood:' } } };
-  const dbmStub = {
-    loadCollection: async (col) => (col === 'characters' ? charData : shopData),
-    saveCollection: async () => {},
-  };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
-  mockModule(path.join(root, 'database-manager.js'), dbmStub);
   mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [{ character_id:'Player#0001', item_id:'Wood', quantity:2, name:'Wood', category:'Resources' }] }) });
+  mockModule(path.join(root, 'db/inventory.js'), { getCount: async () => 0 });
   mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
   mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
   mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });
@@ -53,16 +47,10 @@ test('createCategoryEmbed shows items for category', async () => {
 test('createCategoryEmbed handles misc category', async () => {
   delete require.cache[require.resolve(shopPath)];
 
-  const charData = { 'Player#0001': { numericID: 'player1' } };
-  const shopData = { Mystery: { data: { category: 'Misc', icon: ':?' } } };
-  const dbmStub = {
-    loadCollection: async (col) => (col === 'characters' ? charData : shopData),
-    saveCollection: async () => {},
-  };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
-  mockModule(path.join(root, 'database-manager.js'), dbmStub);
   mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [{ character_id:'Player#0001', item_id:'Mystery', quantity:1, name:'Mystery', category:'Misc' }] }) });
+  mockModule(path.join(root, 'db/inventory.js'), { getCount: async () => 0 });
   mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
   mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
   mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });

--- a/tests/inventory-items.test.js
+++ b/tests/inventory-items.test.js
@@ -26,20 +26,10 @@ function mockModule(modulePath, mock) {
 }
 
 test('inventory embed shows non-stackable items', async () => {
-  const charData = {
-    'Player#0001': { numericID: 'player1' }
-  };
-  const shopData = {
-    Sword: { data: { category: 'Weapons', icon: ':sword:' } }
-  };
-  const dbmStub = {
-    loadCollection: async (col) => (col === 'characters' ? charData : shopData),
-    saveCollection: async () => {},
-  };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
-  mockModule(path.join(root, 'database-manager.js'), dbmStub);
   mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [{ character_id:'Player#0001', item_id:'Sword', quantity:1, name:'Sword', category:'Weapons' }] }) });
+  mockModule(path.join(root, 'db/inventory.js'), { getCount: async () => 0 });
   mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
   mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
   mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });
@@ -51,20 +41,10 @@ test('inventory embed shows non-stackable items', async () => {
 });
 
 test('inventory embed includes legacy inline inventory', async () => {
-  const charData = {
-    'Player#0001': { numericID: 'player1' }
-  };
-  const shopData = {
-    Apple: { data: { category: 'Food', icon: ':apple:' } }
-  };
-  const dbmStub = {
-    loadCollection: async (col) => (col === 'characters' ? charData : shopData),
-    saveCollection: async () => {},
-  };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
-  mockModule(path.join(root, 'database-manager.js'), dbmStub);
   mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [{ character_id:'Player#0001', item_id:'Apple', quantity:2, name:'Apple', category:'Food' }] }) });
+  mockModule(path.join(root, 'db/inventory.js'), { getCount: async () => 0 });
   mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
   mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
   mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });

--- a/tests/inventory-view.test.js
+++ b/tests/inventory-view.test.js
@@ -64,12 +64,7 @@ const { newDb, DataType } = require('pg-mem');
 
   await pool.query('INSERT INTO items (id, category, data) VALUES ($1, $2, $3)', [itemName, category, {}]);
   await pool.query('INSERT INTO shop (id, name, item_id, price, data) VALUES ($1, $2, $3, $4, $5)', [itemName, itemName, itemName, 10, { channels: '', need_role: '', give_role: '' }]);
-
-  const dbmStub = {
-    loadFile: async () => ({ numericID: 'usernum' }),
-    getBalance: async () => 100,
-    saveFile: async () => {}
-  };
+  await pool.query('INSERT INTO balances (id, amount) VALUES ($1, $2)', ['Player#0001', 100]);
 
   const dbStub = {
     query: (text, params) => pool.query(text, params),
@@ -91,8 +86,8 @@ const { newDb, DataType } = require('pg-mem');
   };
 
   const shopModule = await mockImport(shopPath, {
-    './database-manager': dbmStub,
     './pg-client': dbStub,
+    './db/inventory': { getCount: async () => 0 },
     './db/items': { getItemMetaByCode: async code => ({ item_code: code, name: code }) },
     './clientManager': { getUser: async () => ({ roles: { cache: { some: () => false }, add: () => {} } }) },
     './logger': { debug() {}, info() {}, error() {} },

--- a/tests/panel-category.test.js
+++ b/tests/panel-category.test.js
@@ -29,19 +29,8 @@ function mockModule(modulePath, mock) {
 }
 
 test('resources and ships appear only in their submenus', async () => {
-  const charData = {
-    'Player#0001': {
-      balance: 0,
-      numericID: 'player1'
-    }
-  };
-  const dbmStub = {
-    loadCollection: async (col) => (col === 'characters' ? charData : {}),
-    saveCollection: async () => {},
-  };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
-  mockModule(path.join(root, 'database-manager.js'), dbmStub);
   mockModule(path.join(root, 'pg-client.js'), {
     query: async (text, params = []) => {
       if (text.includes("category = 'Resources'")) {

--- a/tests/shop-embed.test.js
+++ b/tests/shop-embed.test.js
@@ -46,7 +46,7 @@ test('createShopEmbed shows only items with numeric prices', async () => {
   const shopModule = await mockImport(shopPath, {
     './pg-client': dbStub,
     'discord.js': discordStub,
-    './database-manager': {},
+    './db/inventory': { getCount: async () => 0 },
     './clientManager': {},
     './dataGetters': {},
     './db/items': { getItemMetaByCode: async code => ({ item_code: code, name: code }) },

--- a/tests/storage-normalized.test.js
+++ b/tests/storage-normalized.test.js
@@ -28,22 +28,10 @@ function mockModule(modulePath, mock) {
 }
 
 test('storage uses normalized inventory when legacy storage empty', async () => {
-  const charData = {
-    'Player#0001': {
-      numericID: 'player1'
-    }
-  };
-  const shopData = {
-    Wood: { data: { category: 'Resources', icon: ':wood:' } }
-  };
-  const dbmStub = {
-    loadCollection: async (col) => (col === 'characters' ? charData : shopData),
-    saveCollection: async () => {},
-  };
   const dataGettersStub = { getCharFromNumericID: async (id) => id };
 
-  mockModule(path.join(root, 'database-manager.js'), dbmStub);
   mockModule(path.join(root, 'pg-client.js'), { query: async () => ({ rows: [{ character_id:'Player#0001', item_id:'Wood', quantity:10, name:'Wood', category:'Resources' }] }) });
+  mockModule(path.join(root, 'db/inventory.js'), { getCount: async () => 0 });
   mockModule(path.join(root, 'clientManager.js'), { getEmoji: () => ':coin:' });
   mockModule(path.join(root, 'dataGetters.js'), dataGettersStub);
   mockModule(path.join(root, 'logger.js'), { debug() {}, info() {}, error() {} });


### PR DESCRIPTION
## Summary
- load inventory module directly and drop database manager fallback
- query balances via PostgreSQL and rely on db/inventory for counts
- update tests to mock inventory module instead of database-manager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e44894354832ea77f3388af086f8f