### PR TITLE
Add marketplace view migration and update item references

### DIFF
--- a/db/marketplace.js
+++ b/db/marketplace.js
@@ -14,7 +14,7 @@ async function listSales({ sellerId, limit, offset, cursor } = {}) {
   }
   const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
   let sql = `
-    SELECT id, name, item_code AS item_id, price, quantity, seller
+    SELECT id, name, item_id, price, quantity, seller
     FROM marketplace_v
     ${where}
     ORDER BY ${cursor ? 'id' : 'name NULLS LAST'}

--- a/migrations/002_create_marketplace_view.sql
+++ b/migrations/002_create_marketplace_view.sql
@@ -1,0 +1,4 @@
+DROP VIEW IF EXISTS marketplace_v;
+CREATE VIEW marketplace_v AS
+SELECT id, name, item_code AS item_id, price, seller, quantity
+FROM marketplace;

--- a/tests/marketplace-embed.test.js
+++ b/tests/marketplace-embed.test.js
@@ -1,0 +1,40 @@
+const { test, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '..');
+const marketplacePath = path.join(rootDir, 'marketplace.js');
+
+const stubbed = new Set();
+function stubModule(file, exports) {
+  const filePath = path.join(rootDir, file);
+  require.cache[filePath] = { id: filePath, filename: filePath, loaded: true, exports };
+  stubbed.add(filePath);
+}
+
+(function setup() {
+  stubModule('pg-client.js', { pool: {}, query: async () => ({}) });
+  stubModule('db/inventory.js', {});
+  stubModule('db/items.js', {});
+  stubModule('db/marketplace.js', {
+    async listSales() {
+      return {
+        rows: [
+          { id: '1', name: 'Sword', item_id: 'sword', price: 10, quantity: 1, seller: 'user1' },
+        ],
+        totalCount: 1,
+      };
+    },
+  });
+})();
+
+const { createSalesEmbed } = require(marketplacePath);
+
+after(() => {
+  for (const p of stubbed) delete require.cache[p];
+});
+
+test('createSalesEmbed shows item codes', async () => {
+  const [embed] = await createSalesEmbed();
+  assert.match(embed.data.description, /\(sword\)/);
+});

--- a/tests/marketplace.test.js
+++ b/tests/marketplace.test.js
@@ -29,7 +29,7 @@ function stubModule(file, exports) {
     'CREATE TABLE marketplace (id TEXT PRIMARY KEY, name TEXT, item_code TEXT, price INTEGER, seller TEXT, quantity INTEGER)'
   );
   pool.query(
-    "CREATE VIEW marketplace_v AS SELECT id, name, item_code, price, seller, quantity, 'Weapons'::text AS category FROM marketplace"
+    "CREATE VIEW marketplace_v AS SELECT id, name, item_code AS item_id, price, seller, quantity FROM marketplace"
   );
   stubModule('pg-client.js', { pool, query: (text, params) => pool.query(text, params) });
 


### PR DESCRIPTION
## Summary
- define `marketplace_v` view selecting `item_code` as `item_id`
- update marketplace query helpers and tests for new view
- add test ensuring `createSalesEmbed` shows item codes

## Testing
- `npm test`
- `psql -f migrations/002_create_marketplace_view.sql` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e47dc79b4832eb65388c8790b0d6b