### PR TITLE
feat: format inventory command embed

### DIFF
--- a/commands/shopCommands/inventory.js
+++ b/commands/shopCommands/inventory.js
@@ -1,17 +1,74 @@
-const { SlashCommandBuilder } = require('discord.js');
-const { getInventoryView } = require('../../db/inventory');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+const inventory = require('../../db/inventory');
+const db = require('../../pg-client');
 
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('inventory')
 		.setDescription('Show your inventory'),
-	async execute(interaction) {
-        const rows = await getInventoryView(interaction.user.id);
-        if (rows.length === 0) {
-                await interaction.reply({ content: 'No items in inventory!', ephemeral: true });
+        async execute(interaction) {
+        const charId = await characters.ensureAndGetId(interaction.user);
+        const rows = await inventory.getInventoryView(charId);
+
+        const embed = new EmbedBuilder().setTitle('Inventory').setColor(0x36393e);
+
+        const itemIds = [...new Set(rows.map((r) => r.item_id))];
+        let iconMap = {};
+        if (itemIds.length > 0) {
+                const { rows: iconRows } = await db.query(
+                `SELECT id, COALESCE(data->>'icon', data->'infoOptions'->>'Icon', '') AS icon
+                   FROM items
+                  WHERE id = ANY($1)`,
+                [itemIds]
+                );
+                for (const r of iconRows) {
+                iconMap[r.id] = r.icon || '';
+                }
+        }
+
+        const inventoryMap = {};
+        for (const row of rows) {
+                const catLower = (row.category || '').toLowerCase();
+                if (catLower === 'ships' || catLower === 'ship' || catLower === 'resources' || catLower === 'resource') {
+                continue;
+                }
+                const category = row.category || 'Misc';
+                if (!inventoryMap[category]) inventoryMap[category] = [];
+                inventoryMap[category].push({
+                item: row.name,
+                qty: Number(row.quantity),
+                icon: iconMap[row.item_id] || '',
+                });
+        }
+
+        const categories = Object.keys(inventoryMap).sort();
+        if (categories.length === 0) {
+                embed.setDescription('No items in inventory!');
+                await interaction.reply({ embeds: [embed], ephemeral: true });
                 return;
         }
-        const lines = rows.map(row => `• ${row.name} — x${row.quantity} [${row.category}]`);
-        await interaction.reply({ content: lines.join('\n'), ephemeral: true });
+
+        let descriptionText = '';
+        for (const category of categories) {
+                let endSpaces = '-';
+                if (20 - category.length - 2 > 0) {
+                endSpaces = '-'.repeat(20 - category.length - 2);
+                }
+                descriptionText += `**\`--${category}${endSpaces}\`**\n`;
+                descriptionText += inventoryMap[category]
+                .map(({ item, qty, icon }) => {
+                        let alignSpaces = ' ';
+                        if (30 - item.length - ('' + qty).length > 0) {
+                        alignSpaces = ' '.repeat(30 - item.length - ('' + qty).length);
+                        }
+                        return `${icon} \`${item}${alignSpaces}${qty}\``;
+                })
+                .join('\n');
+                descriptionText += '\n';
+        }
+
+        embed.setDescription('**Items:** \n' + descriptionText);
+        await interaction.reply({ embeds: [embed], ephemeral: true });
         },
 };

--- a/tests/inventory-command.test.js
+++ b/tests/inventory-command.test.js
@@ -10,32 +10,45 @@ function mockModule(modulePath, mock) {
   require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports: mock };
 }
 
-test('/inventory command uses user id identifier', async (t) => {
+test('/inventory command resolves character and formats embed', async (t) => {
   let calledId;
   mockModule(path.join(root, 'db', 'inventory.js'), {
     getInventoryView: async (id) => {
       calledId = id;
-      return [{ name: 'Test', quantity: 1, category: 'Misc' }];
+      return [{ item_id: 'test', name: 'Test', quantity: 1, category: 'Misc' }];
     },
   });
+  mockModule(path.join(root, 'db', 'characters.js'), {
+    ensureAndGetId: async () => 'char123',
+  });
+  mockModule(path.join(root, 'pg-client.js'), {
+    query: async () => ({ rows: [] }),
+  });
   mockModule('discord.js', {
-    SlashCommandBuilder: class { setName() { return this; } setDescription() { return this; } }
+    SlashCommandBuilder: class { setName() { return this; } setDescription() { return this; } },
+    EmbedBuilder: class {
+      setTitle(t) { this.title = t; return this; }
+      setColor(c) { this.color = c; return this; }
+      setDescription(d) { this.description = d; return this; }
+    },
   });
 
   const command = require(commandPath);
   let replied;
   const interaction = {
-    user: { id: '123456789012345678', tag: 'TestUser#0001' },
-    reply: async (payload) => { replied = payload; }
+    user: { id: '123456789012345678', username: 'TestUser', tag: 'TestUser#0001' },
+    reply: async (payload) => { replied = payload; },
   };
 
   await command.execute(interaction);
-  assert.equal(calledId, '123456789012345678');
-  assert.equal(replied.content, '• Test — x1 [Misc]');
+  assert.equal(calledId, 'char123');
+  assert.ok(/Test/.test(replied.embeds[0].description));
   assert.equal(replied.ephemeral, true);
 
   t.after(() => {
     delete require.cache[require.resolve(path.join(root, 'db', 'inventory.js'))];
+    delete require.cache[require.resolve(path.join(root, 'db', 'characters.js'))];
+    delete require.cache[require.resolve(path.join(root, 'pg-client.js'))];
     delete require.cache[require.resolve('discord.js')];
     delete require.cache[commandPath];
   });


### PR DESCRIPTION
## Summary
- Format `/inventory` command output using panel-style embed
- Resolve character IDs via `ensureAndGetId`
- Update tests for new inventory embed logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e507d4514832ea528d68397cb81f4