### PR TITLE
Use character IDs in buy command

### DIFF
--- a/commands/shopCommands/buy.js
+++ b/commands/shopCommands/buy.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const pool = require('../../pg-client');
 const inventory = require('../../db/inventory');
+const characters = require('../../db/characters');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -18,7 +19,7 @@ module.exports = {
         .setMinValue(1)
     ),
   async execute(interaction) {
-    const userId = interaction.user.id;
+    const userId = await characters.ensureAndGetId(interaction.user);
     const itemCode = interaction.options.getString('item_code');
     const qty = interaction.options.getInteger('quantity') ?? 1;
 


### PR DESCRIPTION
## Summary
- import character lookup so buy command uses character IDs
- use character IDs for balance queries, updates, and inventory grants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e51ecba18832e960e7bf32554ca1d