### PR TITLE
Use canonical IDs and SQL for balance commands

### DIFF
--- a/commands/charCommands/addplayergold.js
+++ b/commands/charCommands/addplayergold.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
-const char = require('../../char'); // Importing the database manager
+const characters = require('../../db/characters');
+const db = require('../../pg-client');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -9,15 +10,14 @@ module.exports = {
         .addIntegerOption(option => option.setName('gold').setDescription('The amount of gold to set').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
-        const player = interaction.options.getUser('player').toString();
+        await characters.ensureAndGetId(interaction.user);
+        const targetUser = interaction.options.getUser('player');
+        const playerId = await characters.ensureAndGetId(targetUser);
         const gold = interaction.options.getInteger('gold');
-        const response = await char.addPlayerGold(player, gold);
-
-        if (response) {
-            //make below ephemeral
-            return interaction.reply({ content: `Added ${gold} to ${player}`, ephemeral: true });
-        } else {
-            return interaction.reply('Something went wrong');
-        }
+        await db.query(
+            'INSERT INTO balances (id, amount) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET amount = balances.amount + EXCLUDED.amount',
+            [playerId, gold]
+        );
+        return interaction.reply({ content: `Added ${gold} to ${targetUser}`, ephemeral: true });
     },
 };

--- a/commands/charCommands/deposit.js
+++ b/commands/charCommands/deposit.js
@@ -1,5 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
-const char = require('../../char'); // Importing the database manager
+const characters = require('../../db/characters');
+const db = require('../../pg-client');
+const dbm = require('../../database-manager');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -9,14 +11,21 @@ module.exports = {
             option.setName('quantity')
                 .setDescription('Quantity to deposit')
                 .setRequired(true)),
-	async execute(interaction) {
-		const charID = interaction.user.tag;
+        async execute(interaction) {
+                const charID = await characters.ensureAndGetId(interaction.user);
         const quantity = interaction.options.getInteger('quantity');
-            let replyEmbed = await char.deposit(charID, quantity);
-            if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
-            } else {
-                await interaction.reply("Deposited " + quantity + " gold to bank");
+            const charData = await dbm.loadFile('characters', charID);
+            if (!charData) {
+                return interaction.reply("You haven't made a character! Use /newchar first");
             }
-	},
+            const { rows } = await db.query('SELECT amount FROM balances WHERE id=$1', [charID]);
+            const balance = rows[0]?.amount || 0;
+            if (balance < quantity) {
+                return interaction.reply("You don't have enough gold!");
+            }
+            await db.query('UPDATE balances SET amount = amount - $2 WHERE id=$1', [charID, quantity]);
+            charData.bank = (charData.bank || 0) + quantity;
+            await dbm.saveFile('characters', charID, charData);
+            await interaction.reply("Deposited " + quantity + " gold to bank");
+        },
 };

--- a/commands/charCommands/givegold.js
+++ b/commands/charCommands/givegold.js
@@ -1,7 +1,8 @@
 //Admin command
 
 const { SlashCommandBuilder } = require('discord.js');
-const char = require('../../char'); // Importing the database manager
+const characters = require('../../db/characters');
+const db = require('../../pg-client');
 const clientManager = require('../../clientManager');
 
 module.exports = {
@@ -11,17 +12,26 @@ module.exports = {
         .addUserOption(option => option.setName('player').setDescription('The player to give gold to').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of gold to give').setRequired(true)),
     async execute(interaction) {
-        const playerGiving = interaction.user.toString();
-        const player = interaction.options.getUser('player').toString();
+        const giverId = await characters.ensureAndGetId(interaction.user);
+        const targetUser = interaction.options.getUser('player');
+        const receiverId = await characters.ensureAndGetId(targetUser);
         const amount = interaction.options.getInteger('amount');
-        const response = await char.giveGoldToPlayer(playerGiving, player, amount);
-
-        if (response == true) {
-            return interaction.reply(`Gave ${clientManager.getEmoji("Gold")} ${amount} to ${player}`);
-        } else if (response == false || !response) {
-            return interaction.reply('Something went wrong');
-        } else {
-            return interaction.reply(response);
+        if (giverId === receiverId) {
+            return interaction.reply("You can't give gold to yourself!");
         }
+        if (amount < 1) {
+            return interaction.reply('Amount must be greater than 0');
+        }
+        const { rows } = await db.query('SELECT amount FROM balances WHERE id=$1', [giverId]);
+        const balance = rows[0]?.amount || 0;
+        if (balance < amount) {
+            return interaction.reply("You don't have enough gold!");
+        }
+        await db.query('UPDATE balances SET amount = amount - $2 WHERE id=$1', [giverId, amount]);
+        await db.query(
+            'INSERT INTO balances (id, amount) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET amount = balances.amount + EXCLUDED.amount',
+            [receiverId, amount]
+        );
+        return interaction.reply(`Gave ${clientManager.getEmoji("Gold")} ${amount} to ${targetUser}`);
     },
 };

--- a/commands/charCommands/transfergold.js
+++ b/commands/charCommands/transfergold.js
@@ -1,7 +1,8 @@
 //Admin command
 
 const { SlashCommandBuilder } = require('discord.js');
-const char = require('../../char'); // Importing the database manager
+const characters = require('../../db/characters');
+const db = require('../../pg-client');
 const clientManager = require('../../clientManager');
 
 module.exports = {
@@ -13,17 +14,28 @@ module.exports = {
         .addUserOption(option => option.setName('playergetting').setDescription('The player to give gold to').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of gold to give').setRequired(true)),
     async execute(interaction) {
-        const playerGiving = interaction.options.getUser('playergiving').toString();
-        const player = interaction.options.getUser('playergetting').toString();
+        await characters.ensureAndGetId(interaction.user);
+        const givingUser = interaction.options.getUser('playergiving');
+        const fromId = await characters.ensureAndGetId(givingUser);
+        const gettingUser = interaction.options.getUser('playergetting');
+        const toId = await characters.ensureAndGetId(gettingUser);
         const amount = interaction.options.getInteger('amount');
-        const response = await char.giveGoldToPlayer(playerGiving, player, amount);
-
-        if (response == true) {
-            return interaction.reply(`Gave ${clientManager.getEmoji("Gold")} ${amount} to ${player}`);
-        } else if (response == false || !response) {
-            return interaction.reply('Something went wrong');
-        } else {
-            return interaction.reply(response);
+        if (fromId === toId) {
+            return interaction.reply("You can't give gold to yourself!");
         }
+        if (amount < 1) {
+            return interaction.reply('Amount must be greater than 0');
+        }
+        const { rows } = await db.query('SELECT amount FROM balances WHERE id=$1', [fromId]);
+        const balance = rows[0]?.amount || 0;
+        if (balance < amount) {
+            return interaction.reply("You don't have enough gold!");
+        }
+        await db.query('UPDATE balances SET amount = amount - $2 WHERE id=$1', [fromId, amount]);
+        await db.query(
+            'INSERT INTO balances (id, amount) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET amount = balances.amount + EXCLUDED.amount',
+            [toId, amount]
+        );
+        return interaction.reply(`Gave ${clientManager.getEmoji("Gold")} ${amount} to ${gettingUser}`);
     },
 };


### PR DESCRIPTION
## Summary
- resolve canonical user IDs with `ensureAndGetId` in gold transfer and bank commands
- update balance adjustments with direct SQL on `balances` table
- drop reliance on user tags for balance lookups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e531ddddc832e8e7c4f0279d8ea91