### PR TITLE
Use canonical character IDs for panel and inventory

### DIFF
--- a/commands/charCommands/panel.js
+++ b/commands/charCommands/panel.js
@@ -1,12 +1,14 @@
 const { SlashCommandBuilder } = require('discord.js');
 const panel = require('../../panel');
+const characters = require('../../db/characters');
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('panel')
     .setDescription('Open character panel'),
   async execute(interaction) {
-    const [embed, rows] = await panel.mainEmbed(interaction.user.id);
+    const charId = await characters.ensureAndGetId(interaction.user);
+    const [embed, rows] = await panel.mainEmbed(charId);
     await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
   },
 };

--- a/commands/shopCommands/inventoryadmin.js
+++ b/commands/shopCommands/inventoryadmin.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const characters = require('../../db/characters');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,7 +13,8 @@ module.exports = {
 				.setRequired(true)
 		),
 	async execute(interaction) {
-        const userID = interaction.options.getUser('user').tag;
+        const user = interaction.options.getUser('user');
+        const userID = await characters.ensureAndGetId(user);
                 const [replyEmbed, rows] = await shop.createInventoryEmbed(userID, 1);
                 await interaction.reply({ embeds: [replyEmbed], components: rows });
         },

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -8,6 +8,7 @@ const dbm = require('./database-manager');
 const db = require('./pg-client');
 const { ensureItem } = require('./inventory-grants');
 const { randomUUID } = require('crypto');
+const characters = require('./db/characters');
 
 const sanitizeCategory = (category) => {
   const sanitized = (category || '').trim().toLowerCase();
@@ -214,34 +215,38 @@ const helpSwitch = async (interaction) => {
 
 const panelInvSwitch = async (interaction) => {
   const page = parseInt(interaction.customId.slice(15));
-  let [edittedEmbed, rows] = await panel.inventoryEmbed(interaction.user.tag, page);
+  const charId = await characters.ensureAndGetId(interaction.user);
+  let [edittedEmbed, rows] = await panel.inventoryEmbed(charId, page);
   await interaction.update({ embeds: [edittedEmbed], components: rows });
 };
 
 const panelStoreSwitch = async (interaction) => {
   const page = parseInt(interaction.customId.slice(16));
-  let [edittedEmbed, rows] = await panel.storageEmbed(interaction.user.id, page);
+  const charId = await characters.ensureAndGetId(interaction.user);
+  let [edittedEmbed, rows] = await panel.storageEmbed(charId, page);
   await interaction.update({ embeds: [edittedEmbed], components: rows });
 };
 
 const panelShipSwitch = async (interaction) => {
   const page = parseInt(interaction.customId.slice(15));
-  let [edittedEmbed, rows] = await panel.shipsEmbed(interaction.user.id, page);
+  const charId = await characters.ensureAndGetId(interaction.user);
+  let [edittedEmbed, rows] = await panel.shipsEmbed(charId, page);
   await interaction.update({ embeds: [edittedEmbed], components: rows });
 };
 
 const panelSelect = async (interaction) => {
   const choice = interaction.values[0];
+  const charId = await characters.ensureAndGetId(interaction.user);
   let edittedEmbed;
   let rows;
   if (choice === 'inventory') {
-    [edittedEmbed, rows] = await panel.inventoryEmbed(interaction.user.tag, 1);
+    [edittedEmbed, rows] = await panel.inventoryEmbed(charId, 1);
   } else if (choice === 'resources') {
-    [edittedEmbed, rows] = await panel.storageEmbed(interaction.user.id, 1);
+    [edittedEmbed, rows] = await panel.storageEmbed(charId, 1);
   } else if (choice === 'ships') {
-    [edittedEmbed, rows] = await panel.shipsEmbed(interaction.user.id, 1);
+    [edittedEmbed, rows] = await panel.shipsEmbed(charId, 1);
   } else {
-    [edittedEmbed, rows] = await panel.mainEmbed(interaction.user.id);
+    [edittedEmbed, rows] = await panel.mainEmbed(charId);
   }
   await interaction.update({ embeds: [edittedEmbed], components: rows });
 };

--- a/panel.js
+++ b/panel.js
@@ -39,16 +39,12 @@ function selectRow() {
 
 module.exports = {
   mainEmbed: async function (charID) {
-    charID = await dataGetters.getCharFromNumericID(charID);
-    let charExists = false;
-    if (charID !== 'ERROR') {
-      const { rows } = await db.query(
-        'SELECT 1 FROM characters WHERE id = $1',
-        [charID]
-      );
-      charExists = rows.length > 0;
-    }
-    if (charID === 'ERROR' || !charExists) {
+    const { rows } = await db.query(
+      'SELECT 1 FROM characters WHERE id = $1',
+      [charID]
+    );
+    const charExists = rows.length > 0;
+    if (!charExists) {
       const embed = new EmbedBuilder()
         .setColor(0x36393e)
         .setDescription('Character not found.');
@@ -66,18 +62,14 @@ module.exports = {
   },
 
   inventoryEmbed: async function (charID, page = 1) {
-    charID = await dataGetters.getCharFromNumericID(charID);
     page = Number(page);
     const itemsPerPage = 25;
-    let charExists = false;
-    if (charID !== 'ERROR') {
-      const { rows } = await db.query(
-        'SELECT 1 FROM characters WHERE id = $1',
-        [charID]
-      );
-      charExists = rows.length > 0;
-    }
-    if (charID === 'ERROR' || !charExists) {
+    const { rows: charRows } = await db.query(
+      'SELECT 1 FROM characters WHERE id = $1',
+      [charID]
+    );
+    const charExists = charRows.length > 0;
+    if (!charExists) {
       const embed = new EmbedBuilder()
         .setColor(0x36393e)
         .setDescription('Character not found.');

--- a/tests/panel-errors.test.js
+++ b/tests/panel-errors.test.js
@@ -46,7 +46,6 @@ function discordStub() {
 
 test('mainEmbed returns error when character lookup fails', async (t) => {
   const { panel, cleanup } = loadPanelWithMocks({
-    './dataGetters.js': { getCharFromNumericID: async () => 'ERROR' },
     './database-manager.js': { loadCollection: async () => ({}) },
     './clientManager.js': { getEmoji: () => ':coin:' },
     './shop.js': {},
@@ -62,7 +61,6 @@ test('mainEmbed returns error when character lookup fails', async (t) => {
 
 test('mainEmbed returns error when character data missing', async (t) => {
   const { panel, cleanup } = loadPanelWithMocks({
-    './dataGetters.js': { getCharFromNumericID: async () => 'User#0001' },
     './database-manager.js': { loadCollection: async () => ({}) },
     './clientManager.js': { getEmoji: () => ':coin:' },
     './shop.js': {},

--- a/tests/panel-interactions.test.js
+++ b/tests/panel-interactions.test.js
@@ -38,6 +38,7 @@ function setupHandler(panelImpl) {
   pool = new pgMem.Pool();
   stubModule('pg-client.js', { query: (text, params) => pool.query(text, params), pool });
   stubModule('panel.js', panelImpl);
+  stubModule('db/characters.js', { ensureAndGetId: async (user) => user.tag });
   delete require.cache[handlerPath];
   return require(handlerPath);
 }
@@ -100,7 +101,7 @@ function panelSelectTest(choice, expectedFn) {
     const interaction = createSelectInteraction(choice);
     await handler.handle(interaction);
     assert.equal(called.fn, expectedFn);
-    const expectedId = expectedFn === 'inventory' ? 'TestUser#0001' : '123456789012345678';
+    const expectedId = 'TestUser#0001';
     assert.equal(called.id, expectedId);
     if (called.page) assert.equal(called.page, 1);
     const expectedEmbed = {
@@ -137,7 +138,7 @@ function paginationTest(customId, expectedFn, expectedPage) {
     const interaction = createButtonInteraction(customId);
     await handler.handle(interaction);
     assert.equal(called.fn, expectedFn);
-    const expectedId = expectedFn === 'inventory' ? 'TestUser#0001' : '123456789012345678';
+    const expectedId = 'TestUser#0001';
     assert.deepEqual(called, { fn: expectedFn, id: expectedId, page: expectedPage });
     const expectedEmbed = {
       inventory: 'invEmbed',


### PR DESCRIPTION
## Summary
- retrieve canonical IDs in `/panel` and inventory admin commands
- refactor panel embeds to accept canonical IDs directly
- adjust interaction handler to resolve user IDs for panel navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e54d4ce2c832ea66589446b9c37df