### PR TITLE
Add robust error handling for sales commands

### DIFF
--- a/commands/salesCommands/buysale.js
+++ b/commands/salesCommands/buysale.js
@@ -14,15 +14,24 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-        const saleID = interaction.options.getString('saleid');
-        const userTag = interaction.user.tag;
-        const userID = await characters.ensureAndGetId(interaction.user);
-        let replyString = await buySale(saleID, userTag, userID);
-        //if embed, display embed, otherwise display string
-        if (typeof (replyString) == 'string') {
-            await interaction.reply(replyString);
-        } else {
-            await interaction.reply({ embeds: [replyString] });
+        try {
+            const saleID = interaction.options.getString('saleid');
+            const userTag = interaction.user.tag;
+            const userID = await characters.ensureAndGetId(interaction.user);
+            let replyString = await buySale(saleID, userTag, userID);
+            //if embed, display embed, otherwise display string
+            if (typeof (replyString) == 'string') {
+                await interaction.reply(replyString);
+            } else {
+                await interaction.reply({ embeds: [replyString] });
+            }
+        } catch (err) {
+            console.error(err.stack);
+            if (interaction.replied || interaction.deferred) {
+                await interaction.followUp({ content: 'Failed to process your request.', ephemeral: true });
+            } else {
+                await interaction.reply({ content: 'Failed to process your request.', ephemeral: true });
+            }
         }
     },
 };

--- a/commands/salesCommands/inspectsale.js
+++ b/commands/salesCommands/inspectsale.js
@@ -13,13 +13,22 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-        const saleID = interaction.options.getString('saleid');
-        let replyString = await inspectSale(saleID);
-        //if embed, display embed, otherwise display string
-        if (typeof (replyString) == 'string') {
-            await interaction.reply(replyString);
-        } else {
-            await interaction.reply({ embeds: [replyString] });
+        try {
+            const saleID = interaction.options.getString('saleid');
+            let replyString = await inspectSale(saleID);
+            //if embed, display embed, otherwise display string
+            if (typeof (replyString) == 'string') {
+                await interaction.reply(replyString);
+            } else {
+                await interaction.reply({ embeds: [replyString] });
+            }
+        } catch (err) {
+            console.error(err.stack);
+            if (interaction.replied || interaction.deferred) {
+                await interaction.followUp({ content: 'Failed to process your request.', ephemeral: true });
+            } else {
+                await interaction.reply({ content: 'Failed to process your request.', ephemeral: true });
+            }
         }
     },
 };

--- a/commands/salesCommands/sales.js
+++ b/commands/salesCommands/sales.js
@@ -17,52 +17,61 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
-        const perPage = 10;
-        let page = interaction.options.getInteger('page') ?? 1;
-        page = Math.max(1, Number(page) || 1);
-        let offset = (page - 1) * perPage;
+        try {
+            const perPage = 10;
+            let page = interaction.options.getInteger('page') ?? 1;
+            page = Math.max(1, Number(page) || 1);
+            let offset = (page - 1) * perPage;
 
-        let { rows: sales, totalCount } = await marketplace.listSales({ limit: perPage, offset });
-        const totalPages = Math.max(1, Math.ceil(totalCount / perPage));
-        if (page > totalPages) {
-            page = totalPages;
-            offset = (page - 1) * perPage;
-            ({ rows: sales } = await marketplace.listSales({ limit: perPage, offset }));
-        }
-
-        const description = sales
-            .map(({ name, item_id, price, quantity, seller }) =>
-                `• ${quantity}× ${name} (${item_id}) — ${price ?? 'N/A'} gold — Seller: <@${seller}>`
-            )
-            .join('\n');
-
-        const embed = new EmbedBuilder()
-            .setTitle('Marketplace Listings')
-            .setDescription(description || 'No sales found.')
-            .setFooter({ text: `Page ${page} of ${totalPages}` });
-
-        const rows = [];
-        if (totalPages > 1) {
-            const row = new ActionRowBuilder();
-            if (page > 1) {
-                row.addComponents(
-                    new ButtonBuilder()
-                        .setCustomId(`salesSwitch${page - 1}`)
-                        .setLabel('Prev')
-                        .setStyle(ButtonStyle.Primary)
-                );
+            let { rows: sales, totalCount } = await marketplace.listSales({ limit: perPage, offset });
+            const totalPages = Math.max(1, Math.ceil(totalCount / perPage));
+            if (page > totalPages) {
+                page = totalPages;
+                offset = (page - 1) * perPage;
+                ({ rows: sales } = await marketplace.listSales({ limit: perPage, offset }));
             }
-            if (page < totalPages) {
-                row.addComponents(
-                    new ButtonBuilder()
-                        .setCustomId(`salesSwitch${page + 1}`)
-                        .setLabel('Next')
-                        .setStyle(ButtonStyle.Primary)
-                );
-            }
-            rows.push(row);
-        }
 
-        await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
+            const description = sales
+                .map(({ name, item_id, price, quantity, seller }) =>
+                    `• ${quantity}× ${name} (${item_id}) — ${price ?? 'N/A'} gold — Seller: <@${seller}>`
+                )
+                .join('\n');
+
+            const embed = new EmbedBuilder()
+                .setTitle('Marketplace Listings')
+                .setDescription(description || 'No sales found.')
+                .setFooter({ text: `Page ${page} of ${totalPages}` });
+
+            const rows = [];
+            if (totalPages > 1) {
+                const row = new ActionRowBuilder();
+                if (page > 1) {
+                    row.addComponents(
+                        new ButtonBuilder()
+                            .setCustomId(`salesSwitch${page - 1}`)
+                            .setLabel('Prev')
+                            .setStyle(ButtonStyle.Primary)
+                    );
+                }
+                if (page < totalPages) {
+                    row.addComponents(
+                        new ButtonBuilder()
+                            .setCustomId(`salesSwitch${page + 1}`)
+                            .setLabel('Next')
+                            .setStyle(ButtonStyle.Primary)
+                    );
+                }
+                rows.push(row);
+            }
+
+            await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
+        } catch (err) {
+            console.error(err.stack);
+            if (interaction.replied || interaction.deferred) {
+                await interaction.followUp({ content: 'Failed to process your request.', ephemeral: true });
+            } else {
+                await interaction.reply({ content: 'Failed to process your request.', ephemeral: true });
+            }
+        }
     },
 };


### PR DESCRIPTION
## Summary
- wrap sales-related command execute logic in try/catch blocks
- log stack traces and reply with an ephemeral error message on failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e657f0b10832e848ec0bc79337b8c