### PR TITLE
Refactor incomes command to avoid user id usage

### DIFF
--- a/char.js
+++ b/char.js
@@ -411,12 +411,13 @@ class char {
     }
   }
 
-  static async incomes(userID, numericID) {
+  static async incomes(charID) {
     let collectionName = 'characters';
 
     // Load the data
-    let charData = await dbm.loadFile(collectionName, userID);
+    let charData = await dbm.loadFile(collectionName, charID);
     let incomeListFromRoles = await dbm.loadFile('keys', 'incomeList');
+    const numericID = charData.numeric_id;
 
     var now = new Date();
 
@@ -517,11 +518,11 @@ class char {
       superstring += "\n";
     }
 
-    await this.changeBalance(userID, total);
+    await this.changeBalance(charID, total);
     superstring +=  clientManager.getEmoji("Gold") + " **__Total Gold :__** `" + total + "`\n";
 
     for (let [resource, amount] of Object.entries(resourceMap)) {
-      await this.changeInventory(userID, resource, amount);
+      await this.changeInventory(charID, resource, amount);
       superstring += clientManager.getEmoji(resource) + " **__Total " + resource + " :__** `" + amount + "`\n";
     }
 
@@ -544,7 +545,7 @@ class char {
     
     charData.incomeAvailable = false;
 
-    await dbm.saveFile(collectionName, userID, charData);
+    await dbm.saveFile(collectionName, charID, charData);
     
     const incomeEmbed = {
       color: 0x36393e,

--- a/commands/charCommands/incomes.js
+++ b/commands/charCommands/incomes.js
@@ -1,0 +1,28 @@
+const { SlashCommandBuilder } = require('discord.js');
+const char = require('../../char');
+const characters = require('../../db/characters');
+const logger = require('../../logger');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('incomes')
+        .setDescription('Collect your daily incomes'),
+    async execute(interaction) {
+        try {
+            const charID = await characters.ensureAndGetId(interaction.user);
+            const [replyEmbed, replyString] = await char.incomes(charID);
+            await interaction.reply({ embeds: [replyEmbed] });
+            if (replyString) {
+                await interaction.channel.send(replyString);
+            }
+        } catch (error) {
+            logger.error('Failed to collect incomes', error);
+            const content = 'An error occurred while collecting incomes. Please try again later.';
+            if (interaction.deferred || interaction.replied) {
+                await interaction.followUp({ content, ephemeral: true });
+            } else {
+                await interaction.reply({ content, ephemeral: true });
+            }
+        }
+    },
+};


### PR DESCRIPTION
## Summary
- add new `incomes` command under character commands
- refactor `char.incomes` to derive user id from character data
- handle errors during income collection with friendly messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e6f3d32d4832e862bd4bf252719e6