### PR TITLE
Add incomes table and helpers

### DIFF
--- a/database-manager.js
+++ b/database-manager.js
@@ -56,6 +56,18 @@ async function init() {
      )`
   );
 
+  await db.query(
+    `CREATE TABLE IF NOT EXISTS incomes (
+       name       TEXT PRIMARY KEY,
+       gold_given INTEGER,
+       item_code  TEXT,
+       item_amount INTEGER,
+       emoji      TEXT,
+       roles      JSONB,
+       delay      TEXT
+     )`
+  );
+
   // normalized tables for balances, inventories, inventory items and cooldowns
   await db.query(
     'CREATE TABLE IF NOT EXISTS balances (id TEXT PRIMARY KEY, amount INTEGER DEFAULT 0)'

--- a/db/incomes.js
+++ b/db/incomes.js
@@ -1,0 +1,46 @@
+// db/incomes.js
+const pool = require('../pg-client');
+
+async function getAll() {
+  const { rows } = await pool.query(
+    `SELECT name, gold_given, item_code, item_amount, emoji, roles, delay FROM incomes`
+  );
+  return rows;
+}
+
+async function add(name, fields = {}) {
+  const columns = ['name'];
+  const params = [name];
+  const placeholders = ['$1'];
+  let i = 2;
+  for (const [key, value] of Object.entries(fields)) {
+    columns.push(key);
+    params.push(value);
+    placeholders.push(`$${i++}`);
+  }
+  const sql = `INSERT INTO incomes (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) RETURNING *`;
+  const { rows } = await pool.query(sql, params);
+  return rows[0];
+}
+
+async function update(name, fields = {}) {
+  const entries = Object.entries(fields);
+  if (entries.length === 0) return null;
+  const sets = [];
+  const params = [];
+  let i = 1;
+  for (const [key, value] of entries) {
+    sets.push(`${key} = $${i++}`);
+    params.push(value);
+  }
+  params.push(name);
+  const sql = `UPDATE incomes SET ${sets.join(', ')} WHERE name = $${i} RETURNING *`;
+  const { rows } = await pool.query(sql, params);
+  return rows[0];
+}
+
+async function remove(name) {
+  await pool.query('DELETE FROM incomes WHERE name = $1', [name]);
+}
+
+module.exports = { getAll, add, update, remove };


### PR DESCRIPTION
## Summary
- add database helpers for incomes table
- create incomes table during database initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f08afada0832e9c7bb5e170f6434e