### PR TITLE
Refactor income commands to use Postgres-backed admin API

### DIFF
--- a/commands/adminCommands/addIncome.js
+++ b/commands/adminCommands/addIncome.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -19,13 +19,8 @@ module.exports = {
     async execute(interaction) {
         const role = interaction.options.getRole('role');
         const income = interaction.options.getString('income');
-            //addIncome(roleID, incomeString)
-            let reply = await admin.addIncome(role, income);
-            if (typeof(reply) == 'string') {
-                await interaction.reply(reply);
-            } else {
-                await interaction.reply({ embeds: [reply] });
-            }
-            // Call the useItem function from the Shop class
+
+        const reply = await admin.addIncome(role, income);
+        await interaction.reply(reply);
     }
-};
+  };

--- a/commands/adminCommands/allincomes.js
+++ b/commands/adminCommands/allincomes.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {
@@ -9,17 +9,18 @@ module.exports = {
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
         await interaction.deferReply();
-		try {
-            let reply = await admin.allIncomes(1);
-            if (typeof(reply) == 'string') {
+                try {
+            const reply = await admin.allIncomes(1);
+            if (typeof reply === 'string') {
                 await interaction.editReply(reply);
             } else {
-                let [embed, rows] = reply;
-                await interaction.editReply(({ embeds: [embed], components: rows}));
+                const [embed, rows] = reply;
+                await interaction.editReply({ embeds: [embed], components: rows });
             }
         } catch (error) {
             logger.error("Failed to get incomes", error);
             await interaction.editReply({ content: "An error was caught. Contact Alex.", ephemeral: true });
         }
-	},
+        },
 };
+

--- a/commands/adminCommands/editincomefield.js
+++ b/commands/adminCommands/editincomefield.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 ///editfield <field number> <new value>
 module.exports = {
@@ -29,11 +29,7 @@ module.exports = {
             newValue = "DELETEFIELD";
         }
 
-        let reply = await admin.editIncomeField(fieldNumber, interaction.user.tag, newValue);
-        if (typeof(reply) == 'string') {
-            await interaction.reply(reply);
-        } else {
-            await interaction.reply({ embeds: [reply] });
-        }
+        const reply = await admin.editIncomeField(fieldNumber, interaction.user.tag, newValue);
+        await interaction.reply(reply);
     }
 };

--- a/commands/adminCommands/editincomemenu.js
+++ b/commands/adminCommands/editincomemenu.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,14 +12,12 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-        const role = interaction.options.getString('income');
-            //addIncome(roleID, incomeString)
-            let reply = await admin.editIncomeMenu(role, interaction.user.tag);
-            if (typeof(reply) == 'string') {
-                await interaction.reply(reply);
-            } else {
-                await interaction.reply({ embeds: [reply] });
-            }
-            // Call the useItem function from the Shop class
+        const income = interaction.options.getString('income');
+        const reply = await admin.editIncomeMenu(income, interaction.user.tag);
+        if (typeof reply === 'string') {
+            await interaction.reply(reply);
+        } else {
+            await interaction.reply({ embeds: [reply] });
+        }
     }
 };

--- a/commands/adminCommands/removeincome.js
+++ b/commands/adminCommands/removeincome.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const shop = require('../../shop'); // Importing the database manager
+const incomes = require('../../db/incomes');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -12,14 +12,9 @@ module.exports = {
             .setRequired(true)
         ),
     async execute(interaction) {
-        const itemName = interaction.options.getString('income');
-            let returnString = await shop.removeIncome(itemName);
+        const incomeName = interaction.options.getString('income');
 
-			if (returnString) {
-				await interaction.reply(returnString);
-			} else {
-				await interaction.reply(`Income '${itemName}' has been removed.`);
-			}
-            // Call the addItem function from the Shop class
+        await incomes.remove(incomeName);
+        await interaction.reply(`Income '${incomeName}' has been removed.`);
     },
-};
+  };


### PR DESCRIPTION
## Summary
- simplify addincome and editincomefield responses to new admin return types
- clean up income menu commands and listings for Postgres
- remove income entries directly through db/incomes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f0b71d7d4832ea56ead8857bd278b