### PR TITLE
Use item_code alias for marketplace listing IDs

### DIFF
--- a/db/marketplace.js
+++ b/db/marketplace.js
@@ -14,7 +14,7 @@ async function listSales({ sellerId, limit, offset, cursor } = {}) {
   }
   const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
   let sql = `
-    SELECT id, name, item_id, price, quantity, seller
+    SELECT id, name, item_code AS item_id, price, quantity, seller
     FROM marketplace_v
     ${where}
     ORDER BY ${cursor ? 'id' : 'name NULLS LAST'}


### PR DESCRIPTION
## Summary
- align marketplace listings with schema updates by selecting `item_code` as `item_id`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f2bf3b3c8832e84b2f4b39f455762