### PR TITLE
Stringify array values in income params

### DIFF
--- a/db/incomes.js
+++ b/db/incomes.js
@@ -15,7 +15,7 @@ async function add(name, fields = {}) {
   let i = 2;
   for (const [key, value] of Object.entries(fields)) {
     columns.push(key);
-    params.push(value);
+    params.push(Array.isArray(value) ? JSON.stringify(value) : value);
     placeholders.push(`$${i++}`);
   }
   const sql = `INSERT INTO incomes (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) RETURNING *`;
@@ -31,7 +31,7 @@ async function update(name, fields = {}) {
   let i = 1;
   for (const [key, value] of entries) {
     sets.push(`${key} = $${i++}`);
-    params.push(value);
+    params.push(Array.isArray(value) ? JSON.stringify(value) : value);
   }
   params.push(name);
   const sql = `UPDATE incomes SET ${sets.join(', ')} WHERE name = $${i} RETURNING *`;


### PR DESCRIPTION
## Summary
- JSON.stringify array values in `add` and `update` when building SQL parameters for incomes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f2d197994832e9c6ab7c86bb357a6