### PR TITLE
Add error handling to income admin commands

### DIFF
--- a/commands/adminCommands/addIncome.js
+++ b/commands/adminCommands/addIncome.js
@@ -17,10 +17,15 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-        const role = interaction.options.getRole('role');
-        const income = interaction.options.getString('income');
+        try {
+            const role = interaction.options.getRole('role');
+            const income = interaction.options.getString('income');
 
-        const reply = await admin.addIncome(role, income);
-        await interaction.reply(reply);
+            const reply = await admin.addIncome(role, income);
+            await interaction.reply(reply);
+        } catch (err) {
+            console.error(err.stack);
+            await interaction.reply({ content: 'Failed to process your request.', ephemeral: true });
+        }
     }
   };

--- a/commands/adminCommands/editincomefield.js
+++ b/commands/adminCommands/editincomefield.js
@@ -18,18 +18,23 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
-        const fieldNumber = interaction.options.getInteger('fieldnumber');
-        let newValue;
-        if (interaction.options.getString('newvalue') == null) {
-            return await interaction.reply('If you want to remove a field, please make the new value "DELETE" in all caps');
-        } else {
-            newValue = interaction.options.getString('newvalue');
-        }
-        if (newValue == 'DELETE') {
-            newValue = "DELETEFIELD";
-        }
+        try {
+            const fieldNumber = interaction.options.getInteger('fieldnumber');
+            let newValue;
+            if (interaction.options.getString('newvalue') == null) {
+                return await interaction.reply('If you want to remove a field, please make the new value "DELETE" in all caps');
+            } else {
+                newValue = interaction.options.getString('newvalue');
+            }
+            if (newValue == 'DELETE') {
+                newValue = "DELETEFIELD";
+            }
 
-        const reply = await admin.editIncomeField(fieldNumber, interaction.user.tag, newValue);
-        await interaction.reply(reply);
+            const reply = await admin.editIncomeField(fieldNumber, interaction.user.tag, newValue);
+            await interaction.reply(reply);
+        } catch (err) {
+            console.error(err.stack);
+            await interaction.reply({ content: 'Failed to process your request.', ephemeral: true });
+        }
     }
 };

--- a/commands/adminCommands/editincomemenu.js
+++ b/commands/adminCommands/editincomemenu.js
@@ -12,12 +12,17 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-        const income = interaction.options.getString('income');
-        const reply = await admin.editIncomeMenu(income, interaction.user.tag);
-        if (typeof reply === 'string') {
-            await interaction.reply(reply);
-        } else {
-            await interaction.reply({ embeds: [reply] });
+        try {
+            const income = interaction.options.getString('income');
+            const reply = await admin.editIncomeMenu(income, interaction.user.tag);
+            if (typeof reply === 'string') {
+                await interaction.reply(reply);
+            } else {
+                await interaction.reply({ embeds: [reply] });
+            }
+        } catch (err) {
+            console.error(err.stack);
+            await interaction.reply({ content: 'Failed to process your request.', ephemeral: true });
         }
     }
 };


### PR DESCRIPTION
## Summary
- Wrap addIncome, editincomefield, and editincomemenu execute functions in try/catch
- Log error stack and send a user-friendly failure message on exceptions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4025d110832eaf1c081235ca7028