### PR TITLE
feat: migrate player kingdoms to table

### DIFF
--- a/commands/adminCommands/addplayerkingdoms.js
+++ b/commands/adminCommands/addplayerkingdoms.js
@@ -14,8 +14,8 @@ module.exports = {
 	async execute(interaction) {
 		try {
             const kingdom = interaction.options.getRole('kingdom');
-            await admin.addKingdom(kingdom);
-            await interaction.reply({ content: `Added the kingdom ${kingdom} to the list of player kingdoms.`, ephemeral: true });
+            const reply = await admin.addKingdom(kingdom);
+            await interaction.reply({ content: reply, ephemeral: true });
         } catch (error) {
             logger.error("Failed to add map menu:", error);
             await interaction.reply({ content: "Failed to add the kingdom. Please try again.", ephemeral: true });

--- a/commands/adminCommands/listplayerkingdoms.js
+++ b/commands/adminCommands/listplayerkingdoms.js
@@ -9,13 +9,12 @@ module.exports = {
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
         try {
-            let reply = await admin.listKingdoms();
-            //Reply is an embed
-            if (typeof(reply) == 'string') {
-                await interaction.reply({ content: reply, ephemeral: true });
+            const kingdoms = await admin.listKingdoms();
+            if (typeof kingdoms === 'string') {
+                await interaction.reply({ content: kingdoms, ephemeral: true });
                 return;
             }
-            await interaction.reply({ embeds: [reply] });
+            await interaction.reply({ embeds: [kingdoms] });
         } catch (error) {
             logger.error("Failed to get player kingdoms", error);
             await interaction.reply({ content: "An error was caught. Contact Alex.", ephemeral: true });

--- a/db/kingdoms.js
+++ b/db/kingdoms.js
@@ -1,0 +1,20 @@
+const db = require('../pg-client');
+
+async function insert(roleId) {
+  await db.query(
+    'INSERT INTO player_kingdoms (role_id) VALUES ($1) ON CONFLICT (role_id) DO NOTHING',
+    [roleId]
+  );
+}
+
+async function list() {
+  const { rows } = await db.query('SELECT role_id FROM player_kingdoms ORDER BY role_id');
+  return rows.map(r => r.role_id);
+}
+
+async function fetch(roleId) {
+  const { rows } = await db.query('SELECT role_id FROM player_kingdoms WHERE role_id = $1', [roleId]);
+  return rows[0] ? rows[0].role_id : undefined;
+}
+
+module.exports = { insert, list, fetch };

--- a/migrations/004_create_player_kingdoms.sql
+++ b/migrations/004_create_player_kingdoms.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS player_kingdoms (
+  role_id TEXT PRIMARY KEY
+);
+
+INSERT INTO player_kingdoms (role_id)
+SELECT jsonb_array_elements_text(data->'list')
+FROM keys
+WHERE id = 'playerKingdoms'
+ON CONFLICT (role_id) DO NOTHING;
+
+DELETE FROM keys WHERE id = 'playerKingdoms';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add database helpers for player kingdoms
- migrate player kingdoms data from keys table to dedicated table
- refactor admin commands to use new kingdom helpers

## Testing
- `DATABASE_URL=postgresql://localhost/test npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f44e09210832eb367a78fb448d043