### PR TITLE
Add character interaction commands

### DIFF
--- a/commands/charCommands/char.js
+++ b/commands/charCommands/char.js
@@ -1,0 +1,24 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('char')
+    .setDescription('Show character information')
+    .addUserOption(option => option.setName('player').setDescription('Player to inspect')),
+  async execute(interaction) {
+    const target = interaction.options.getUser('player') || interaction.user;
+    const charId = await characters.ensureAndGetId(target);
+    const data = await characters.load(charId);
+    if (!data) {
+      return interaction.reply({ content: 'Character not found.', ephemeral: true });
+    }
+    const embed = {
+      color: 0x36393e,
+      title: data.name || target.tag || target.username,
+      description: data.bio || 'No biography set.',
+    };
+    if (data.avatar) embed.thumbnail = { url: data.avatar };
+    return interaction.reply({ embeds: [embed] });
+  },
+};

--- a/commands/charCommands/editchar.js
+++ b/commands/charCommands/editchar.js
@@ -1,0 +1,23 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('editchar')
+    .setDescription('Edit your character')
+    .addStringOption(option => option.setName('name').setDescription('New name'))
+    .addStringOption(option => option.setName('bio').setDescription('New biography')),
+  async execute(interaction) {
+    const charId = await characters.ensureAndGetId(interaction.user);
+    const data = await characters.load(charId) || {};
+    const name = interaction.options.getString('name');
+    const bio = interaction.options.getString('bio');
+    if (!name && !bio) {
+      return interaction.reply({ content: 'Nothing to update.', ephemeral: true });
+    }
+    if (name) data.name = name;
+    if (bio) data.bio = bio;
+    await characters.save(charId, data);
+    return interaction.reply({ content: 'Character updated.', ephemeral: true });
+  },
+};

--- a/commands/charCommands/me.js
+++ b/commands/charCommands/me.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('me')
+    .setDescription('Show your character information'),
+  async execute(interaction) {
+    const charId = await characters.ensureAndGetId(interaction.user);
+    const data = await characters.load(charId);
+    if (!data) {
+      return interaction.reply({ content: 'You do not have a character yet.', ephemeral: true });
+    }
+    const embed = {
+      color: 0x36393e,
+      title: data.name || interaction.user.tag,
+      description: data.bio || 'No biography set.',
+    };
+    if (data.avatar) embed.thumbnail = { url: data.avatar };
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+  },
+};

--- a/commands/charCommands/newchar.js
+++ b/commands/charCommands/newchar.js
@@ -1,0 +1,33 @@
+const { SlashCommandBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('newchar')
+    .setDescription('Create a new character'),
+  async execute(interaction) {
+    await characters.ensureAndGetId(interaction.user);
+    const modal = new ModalBuilder()
+      .setCustomId('newcharmodal')
+      .setTitle('Create Character');
+
+    const nameInput = new TextInputBuilder()
+      .setCustomId('charname')
+      .setLabel('Name')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true);
+
+    const bioInput = new TextInputBuilder()
+      .setCustomId('charbio')
+      .setLabel('Bio')
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(true);
+
+    modal.addComponents(
+      new ActionRowBuilder().addComponents(nameInput),
+      new ActionRowBuilder().addComponents(bioInput),
+    );
+
+    return interaction.showModal(modal);
+  },
+};

--- a/commands/charCommands/say.js
+++ b/commands/charCommands/say.js
@@ -1,0 +1,26 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('say')
+    .setDescription('Speak as your character')
+    .addStringOption(option => option.setName('message').setDescription('Message to send').setRequired(true)),
+  async execute(interaction) {
+    const charId = await characters.ensureAndGetId(interaction.user);
+    const data = await characters.load(charId);
+    if (!data) {
+      return interaction.reply({ content: 'No character found.', ephemeral: true });
+    }
+    const message = interaction.options.getString('message');
+    const embed = {
+      color: 0x36393e,
+      author: {
+        name: data.name || interaction.user.tag,
+        icon_url: data.avatar || interaction.user.displayAvatarURL(),
+      },
+      description: message,
+    };
+    return interaction.reply({ embeds: [embed] });
+  },
+};

--- a/commands/charCommands/setavatar.js
+++ b/commands/charCommands/setavatar.js
@@ -1,0 +1,17 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('setavatar')
+    .setDescription('Set your character avatar')
+    .addStringOption(option => option.setName('url').setDescription('Image URL').setRequired(true)),
+  async execute(interaction) {
+    const charId = await characters.ensureAndGetId(interaction.user);
+    const data = await characters.load(charId) || {};
+    const url = interaction.options.getString('url');
+    data.avatar = url;
+    await characters.save(charId, data);
+    return interaction.reply({ content: 'Avatar updated.', ephemeral: true });
+  },
+};

--- a/commands/charCommands/stats.js
+++ b/commands/charCommands/stats.js
@@ -1,0 +1,29 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('stats')
+    .setDescription('Show character stats')
+    .addUserOption(option => option.setName('player').setDescription('Player to view')),
+  async execute(interaction) {
+    const target = interaction.options.getUser('player') || interaction.user;
+    const charId = await characters.ensureAndGetId(target);
+    const data = await characters.load(charId);
+    if (!data) {
+      return interaction.reply({ content: 'Character not found.', ephemeral: true });
+    }
+    const stats = data.stats || {};
+    const fields = Object.entries(stats).map(([name, value]) => ({
+      name,
+      value: String(value),
+      inline: true,
+    }));
+    const embed = {
+      color: 0x36393e,
+      title: `${data.name || target.tag} stats`,
+      fields,
+    };
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+  },
+};

--- a/commands/charCommands/warnings.js
+++ b/commands/charCommands/warnings.js
@@ -1,0 +1,28 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('warnings')
+    .setDescription('Show character warnings')
+    .addUserOption(option => option.setName('player').setDescription('Player to view')),
+  async execute(interaction) {
+    const target = interaction.options.getUser('player') || interaction.user;
+    const charId = await characters.ensureAndGetId(target);
+    const data = await characters.load(charId);
+    if (!data) {
+      return interaction.reply({ content: 'Character not found.', ephemeral: true });
+    }
+    const warnings = data.warnings || [];
+    if (!warnings.length) {
+      return interaction.reply({ content: 'No warnings.', ephemeral: true });
+    }
+    const embed = {
+      color: 0x36393e,
+      title: `${data.name || target.tag} warnings`,
+      description: warnings.map((w, i) => `${i + 1}. ${w}`).join('\n'),
+    };
+    const ephemeral = target.id === interaction.user.id;
+    return interaction.reply({ embeds: [embed], ephemeral });
+  },
+};


### PR DESCRIPTION
## Summary
- add /char and /me commands for viewing character profiles
- allow editing, avatar updates, and in-character speech
- expose stats and warning information for characters

## Testing
- `DATABASE_URL=postgresql://localhost/test npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4dd17b08832ea8cb857bfee05bda