### PR TITLE
Add item management commands

### DIFF
--- a/commands/charCommands/craft.js
+++ b/commands/charCommands/craft.js
@@ -1,0 +1,60 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+const items = require('../../db/items');
+const inventory = require('../../db/inventory');
+
+const RECIPES = {
+    potion: { herb: 2, water: 1 },
+};
+
+const cooldowns = new Map();
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('craft')
+        .setDescription('Craft an item from resources')
+        .addStringOption(option => option.setName('item').setDescription('Item to craft').setRequired(true))
+        .addIntegerOption(option => option.setName('quantity').setDescription('Quantity').setMinValue(1)),
+    async execute(interaction) {
+        const userId = await characters.ensureAndGetId(interaction.user);
+        const itemName = interaction.options.getString('item');
+        const qty = interaction.options.getInteger('quantity') ?? 1;
+
+        const now = Date.now();
+        const last = cooldowns.get(userId) || 0;
+        if (now - last < 3000) {
+            return interaction.reply({ content: 'You are crafting too fast.', ephemeral: true });
+        }
+        cooldowns.set(userId, now);
+
+        let itemCode;
+        try {
+            itemCode = await items.resolveItemCode(itemName);
+        } catch (err) {
+            return interaction.reply({ content: err.message, ephemeral: true });
+        }
+
+        const recipe = RECIPES[itemCode];
+        if (!recipe) {
+            return interaction.reply({ content: 'No crafting recipe for that item.', ephemeral: true });
+        }
+
+        for (const [component, amount] of Object.entries(recipe)) {
+            const compCode = await items.resolveItemCode(component);
+            const owned = await inventory.getCount(userId, compCode);
+            if (owned < amount * qty) {
+                return interaction.reply({ content: `You need ${amount * qty} ${component} to craft ${qty}.`, ephemeral: true });
+            }
+        }
+
+        for (const [component, amount] of Object.entries(recipe)) {
+            const compCode = await items.resolveItemCode(component);
+            await inventory.take(userId, compCode, amount * qty);
+        }
+
+        await inventory.give(userId, itemCode, qty);
+        const embed = new EmbedBuilder().setDescription(`Crafted ${qty} ${itemCode}!`);
+        return interaction.reply({ embeds: [embed] });
+    },
+    RECIPES,
+};

--- a/commands/charCommands/crafting.js
+++ b/commands/charCommands/crafting.js
@@ -1,0 +1,18 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { RECIPES } = require('./craft');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('crafting')
+        .setDescription('List available crafting recipes'),
+    async execute(interaction) {
+        const embed = new EmbedBuilder().setTitle('Crafting Recipes');
+        for (const [item, ingredients] of Object.entries(RECIPES)) {
+            const list = Object.entries(ingredients)
+                .map(([key, val]) => `${val}x ${key}`)
+                .join(', ');
+            embed.addFields({ name: item, value: list || 'No ingredients' });
+        }
+        return interaction.reply({ embeds: [embed], ephemeral: true });
+    },
+};

--- a/commands/charCommands/giveitem.js
+++ b/commands/charCommands/giveitem.js
@@ -1,0 +1,29 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+const items = require('../../db/items');
+const inventory = require('../../db/inventory');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('giveitem')
+        .setDescription('Give an item to a player')
+        .addUserOption(option => option.setName('player').setDescription('Player to receive the item').setRequired(true))
+        .addStringOption(option => option.setName('item').setDescription('Item code or name').setRequired(true))
+        .addIntegerOption(option => option.setName('quantity').setDescription('Quantity').setMinValue(1)),
+    async execute(interaction) {
+        const target = interaction.options.getUser('player');
+        const itemName = interaction.options.getString('item');
+        const qty = interaction.options.getInteger('quantity') ?? 1;
+
+        let itemCode;
+        try {
+            itemCode = await items.resolveItemCode(itemName);
+        } catch (err) {
+            return interaction.reply({ content: err.message, ephemeral: true });
+        }
+
+        const receiverId = await characters.ensureAndGetId(target);
+        await inventory.give(receiverId, itemCode, qty);
+        return interaction.reply(`Gave ${qty} ${itemCode} to ${target}`);
+    },
+};

--- a/commands/charCommands/grab.js
+++ b/commands/charCommands/grab.js
@@ -1,0 +1,36 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+const items = require('../../db/items');
+const inventory = require('../../db/inventory');
+const { storageMap } = require('./store');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('grab')
+        .setDescription('Retrieve an item from storage')
+        .addStringOption(option => option.setName('item').setDescription('Item to retrieve').setRequired(true))
+        .addIntegerOption(option => option.setName('quantity').setDescription('Quantity').setMinValue(1)),
+    async execute(interaction) {
+        const userId = await characters.ensureAndGetId(interaction.user);
+        const itemName = interaction.options.getString('item');
+        const qty = interaction.options.getInteger('quantity') ?? 1;
+
+        let itemCode;
+        try {
+            itemCode = await items.resolveItemCode(itemName);
+        } catch (err) {
+            return interaction.reply({ content: err.message, ephemeral: true });
+        }
+
+        const userStore = storageMap.get(userId) || {};
+        const storedQty = userStore[itemCode] || 0;
+        if (storedQty < qty) {
+            return interaction.reply({ content: 'Not enough stored items.', ephemeral: true });
+        }
+
+        userStore[itemCode] = storedQty - qty;
+        storageMap.set(userId, userStore);
+        await inventory.give(userId, itemCode, qty);
+        return interaction.reply(`Retrieved ${qty} ${itemCode}.`);
+    },
+};

--- a/commands/charCommands/store.js
+++ b/commands/charCommands/store.js
@@ -1,0 +1,47 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+const items = require('../../db/items');
+const inventory = require('../../db/inventory');
+
+const storageMap = new Map();
+const cooldowns = new Map();
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('store')
+        .setDescription('Store an item for later')
+        .addStringOption(option => option.setName('item').setDescription('Item to store').setRequired(true))
+        .addIntegerOption(option => option.setName('quantity').setDescription('Quantity').setMinValue(1)),
+    async execute(interaction) {
+        const userId = await characters.ensureAndGetId(interaction.user);
+        const itemName = interaction.options.getString('item');
+        const qty = interaction.options.getInteger('quantity') ?? 1;
+
+        const now = Date.now();
+        const last = cooldowns.get(userId) || 0;
+        if (now - last < 3000) {
+            return interaction.reply({ content: 'Slow down!', ephemeral: true });
+        }
+        cooldowns.set(userId, now);
+
+        let itemCode;
+        try {
+            itemCode = await items.resolveItemCode(itemName);
+        } catch (err) {
+            return interaction.reply({ content: err.message, ephemeral: true });
+        }
+
+        const owned = await inventory.getCount(userId, itemCode);
+        if (owned < qty) {
+            return interaction.reply({ content: 'You do not have enough of that item.', ephemeral: true });
+        }
+
+        await inventory.take(userId, itemCode, qty);
+        const userStore = storageMap.get(userId) || {};
+        userStore[itemCode] = (userStore[itemCode] || 0) + qty;
+        storageMap.set(userId, userStore);
+
+        return interaction.reply(`Stored ${qty} ${itemCode}.`);
+    },
+    storageMap,
+};

--- a/commands/charCommands/useitem.js
+++ b/commands/charCommands/useitem.js
@@ -1,0 +1,39 @@
+const { SlashCommandBuilder } = require('discord.js');
+const characters = require('../../db/characters');
+const items = require('../../db/items');
+const inventory = require('../../db/inventory');
+
+const cooldowns = new Map();
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('useitem')
+        .setDescription('Use an item from your inventory')
+        .addStringOption(option => option.setName('item').setDescription('Item to use').setRequired(true)),
+    async execute(interaction) {
+        const userId = await characters.ensureAndGetId(interaction.user);
+        const itemName = interaction.options.getString('item');
+
+        const now = Date.now();
+        const last = cooldowns.get(userId) || 0;
+        if (now - last < 3000) {
+            return interaction.reply({ content: 'You are using items too quickly.', ephemeral: true });
+        }
+        cooldowns.set(userId, now);
+
+        let itemCode;
+        try {
+            itemCode = await items.resolveItemCode(itemName);
+        } catch (err) {
+            return interaction.reply({ content: err.message, ephemeral: true });
+        }
+
+        const owned = await inventory.getCount(userId, itemCode);
+        if (owned < 1) {
+            return interaction.reply({ content: 'You do not own that item.', ephemeral: true });
+        }
+
+        await inventory.take(userId, itemCode, 1);
+        return interaction.reply(`Used one ${itemCode}.`);
+    },
+};


### PR DESCRIPTION
## Summary
- add crafting, item transfer, and usage commands
- integrate new commands with character and inventory modules

## Testing
- `DATABASE_URL=postgres://localhost/test npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f4f27236c832e8d71dda6a4236dbb