### PR TITLE
Add resolve_item_id migration and update deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ DISCORD_TOKEN=abcdef CLIENT_ID=1234567890 GUILD_ID=0987654321 node bot.js
 On Railway, configure these variables in the project settings. Adding a PostgreSQL service will supply `DATABASE_URL`, and you may
 set `PGPOOL_*` variables to adjust connection pooling.
 
+## Database migrations
+
+Before running the bot, apply the SQL files in the `migrations/` directory to your database. The `005_create_resolve_item_id.sql` migration creates the `resolve_item_id(raw TEXT)` helper used by inventory operations to translate item names or codes to canonical `items.id` values.
+
+Run the migration with `psql` (replace `$DATABASE_URL` with your connection string):
+
+```bash
+psql "$DATABASE_URL" -f migrations/005_create_resolve_item_id.sql
+```
+
+This migration must be executed before performing any inventory operations.
+
 ## /panel command
 
 Use `/panel` to open a personal control panel. The response is ephemeral and visible only to the invoking user. The panel features a select menu with:

--- a/migrations/005_create_resolve_item_id.sql
+++ b/migrations/005_create_resolve_item_id.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION resolve_item_id(raw TEXT)
+RETURNS TEXT AS $$
+DECLARE
+  result TEXT;
+  cnt INTEGER;
+BEGIN
+  SELECT MIN(id), COUNT(*) INTO result, cnt
+    FROM items
+    WHERE id = raw OR LOWER(data->>'name') = LOWER(raw);
+
+  IF cnt = 0 THEN
+    RAISE EXCEPTION 'No item matches "%"', raw;
+  ELSIF cnt > 1 THEN
+    RAISE EXCEPTION 'Multiple items match "%". Use an item code.', raw;
+  END IF;
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
## Summary
- add SQL migration defining `resolve_item_id` for translating item names or codes
- document running migrations, including the new function, before inventory operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f66b42540832ea3462778040b9f29