### PR TITLE
fix(shop): delete by shop.item / data->>'item_id' instead of nonexistent item_code

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -1,3 +1,4 @@
+console.log('[shop.js] using DELETE by item / data->>\'item_id\' / id');
 const db = require('./pg-client');
 const Discord = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
@@ -21,22 +22,19 @@ class shop {
     return res.rows[0] ? res.rows[0].name : 'ERROR';
   }
 
-  static async removeItem(itemName) {
-    let code;
-    try {
-      code = await items.resolveItemCode(itemName);
-    } catch (err) {
-      return `Could not resolve "${itemName}": ${err.message}`;
-    }
-
-    const { rowCount } = await db.query(
-      'DELETE FROM shop WHERE item_code = $1 OR id = $1',
-      [code]
-    );
-    if (rowCount === 0) {
-      return `Item "${itemName}" not found.`;
-    }
-    return null;
+  // accepts either an item code or a row id (string)
+  static async removeItem(codeOrId) {
+    const key = String(codeOrId).trim();
+    const sql = `
+      DELETE FROM shop
+      WHERE
+        item = $1
+        OR (data->>'item_id') = $1
+        OR id = $1
+      RETURNING id, name, item AS item_code, price;
+    `;
+    const { rows } = await db.query(sql, [key]);
+    return rows[0] ?? null;
   }
 
   static async inspect(itemName) {


### PR DESCRIPTION
## Summary
- log new delete logic used in shop.js
- allow removing shop items via item name, data->>'item_id', or row id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a06fd17934832ea687338402ef75d8