### PR TITLE
Query marketplace table directly for sales

### DIFF
--- a/db/marketplace.js
+++ b/db/marketplace.js
@@ -14,8 +14,8 @@ async function listSales({ sellerId, limit, offset, cursor } = {}) {
   }
   const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
   let sql = `
-    SELECT id, name, item_code AS item_id, price, quantity, seller
-    FROM marketplace_v
+    SELECT id, name, item_id, price, quantity, seller
+    FROM marketplace
     ${where}
     ORDER BY ${cursor ? 'id' : 'name NULLS LAST'}
   `;
@@ -30,7 +30,7 @@ async function listSales({ sellerId, limit, offset, cursor } = {}) {
   const { rows } = await pool.query(sql, params);
   let totalCount;
   if (limit !== undefined || offset !== undefined) {
-    const countSql = `SELECT COUNT(*) FROM marketplace_v ${where}`;
+    const countSql = `SELECT COUNT(*) FROM marketplace ${where}`;
     const countParams = params.slice(0, conditions.length);
     const countRes = await pool.query(countSql, countParams);
     totalCount = Number(countRes.rows[0].count);


### PR DESCRIPTION
## Summary
- query marketplace table directly in listSales
- count rows from marketplace table as well

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d3a1fc54832e9621fbbed8eff175