### PR TITLE
Query shop table for item_id

### DIFF
--- a/commands/shopCommands/buy.js
+++ b/commands/shopCommands/buy.js
@@ -23,9 +23,12 @@ module.exports = {
     const itemCode = interaction.options.getString('item_code');
     const qty = interaction.options.getInteger('quantity') ?? 1;
 
-    // read price from shop_v to prevent client-side spoofing
+    // read price from shop to prevent client-side spoofing
     const { rows } = await pool.query(
-      `SELECT price, name FROM shop_v WHERE item_code = $1`,
+      `SELECT (data->>'price')::numeric AS price,
+              data->>'item' AS name
+         FROM shop
+        WHERE data->>'item_id' = $1`,
       [itemCode]
     );
     const row = rows[0];

--- a/db/shop.js
+++ b/db/shop.js
@@ -3,9 +3,12 @@ const { pool } = require('../pg-client');
 
 async function listShopItems() {
   const sql = `
-    SELECT name, item_code, price, category
-    FROM shop_v
-    ORDER BY name
+    SELECT data->>'item' AS name,
+           data->>'item_id' AS item_id,
+           (data->>'price')::numeric AS price,
+           data->'infoOptions'->>'Category' AS category
+      FROM shop
+     ORDER BY name
   `;
   const { rows } = await pool.query(sql);
   return rows;
@@ -13,10 +16,14 @@ async function listShopItems() {
 
 async function getShopItemByNameOrId(nameOrId) {
   const sql = `
-    SELECT name, item_code, price, category
-    FROM shop_v
-    WHERE LOWER(name) = LOWER($1) OR LOWER(item_code) = LOWER($1)
-    LIMIT 1
+    SELECT data->>'item' AS name,
+           data->>'item_id' AS item_id,
+           (data->>'price')::numeric AS price,
+           data->'infoOptions'->>'Category' AS category
+      FROM shop
+     WHERE LOWER(data->>'item') = LOWER($1)
+        OR LOWER(data->>'item_id') = LOWER($1)
+     LIMIT 1
   `;
   const { rows } = await pool.query(sql, [nameOrId]);
   return rows[0] || null;

--- a/tests/buy-item-inventory.test.js
+++ b/tests/buy-item-inventory.test.js
@@ -37,8 +37,8 @@ test('buyItem stores stacks in inventory_items via transaction', async () => {
   const executed = [];
   const dbStub = {
     query: async (text, params) => {
-      if (/FROM\s+shop_v/i.test(text)) {
-        return { rows: [{ id: 1, name: 'Apple', item_code: 'Apple', price: 10, category: 'Food' }] };
+      if (/FROM\s+shop\b/i.test(text)) {
+        return { rows: [{ id: 1, name: 'Apple', item_id: 'Apple', price: 10, category: 'Food' }] };
       }
       if (/FROM\s+balances/i.test(text)) {
         return { rows: [{ amount: balance }] };

--- a/tests/inventory-view.test.js
+++ b/tests/inventory-view.test.js
@@ -48,10 +48,7 @@ const { newDb, DataType } = require('pg-mem');
   await pool.query('CREATE TABLE balances (id TEXT PRIMARY KEY, amount INTEGER DEFAULT 0)');
   await pool.query('CREATE TABLE items (id TEXT PRIMARY KEY, category TEXT, data JSONB)');
   await pool.query('CREATE TABLE inventory_items (instance_id TEXT PRIMARY KEY, owner_id TEXT, item_id TEXT, durability INTEGER, metadata JSONB)');
-  await pool.query('CREATE TABLE shop (id TEXT PRIMARY KEY, name TEXT, item_id TEXT, price INTEGER, data JSONB)');
-  await pool.query(`CREATE VIEW shop_v AS
-    SELECT s.id, s.name, s.item_id AS item_code, s.price, i.category
-      FROM shop s LEFT JOIN items i ON s.item_id = i.id`);
+  await pool.query('CREATE TABLE shop (id TEXT PRIMARY KEY, data JSONB)');
   await pool.query(`CREATE VIEW v_inventory AS
     SELECT ii.owner_id AS character_id,
            ii.item_id,
@@ -63,7 +60,7 @@ const { newDb, DataType } = require('pg-mem');
      GROUP BY ii.owner_id, ii.item_id, it.category`);
 
   await pool.query('INSERT INTO items (id, category, data) VALUES ($1, $2, $3)', [itemName, category, {}]);
-  await pool.query('INSERT INTO shop (id, name, item_id, price, data) VALUES ($1, $2, $3, $4, $5)', [itemName, itemName, itemName, 10, { channels: '', need_role: '', give_role: '' }]);
+  await pool.query('INSERT INTO shop (id, data) VALUES ($1, $2)', [itemName, { item_id: itemName, item: itemName, price: 10, infoOptions: { Category: category } }]);
   await pool.query('INSERT INTO balances (id, amount) VALUES ($1, $2)', ['Player#0001', 100]);
 
   const dbStub = {

--- a/tests/shop-embed.test.js
+++ b/tests/shop-embed.test.js
@@ -26,10 +26,10 @@ const shopPath = path.join(root, 'shop.js');
 
 test('createShopEmbed shows only items with numeric prices', async () => {
   const rows = [
-    { id: 1, name: 'Longboat', item_code: 'longboat', price: 100, category: 'Ships' },
-    { id: 2, name: 'Broken Ship', item_code: 'broken_ship', price: 'abc', category: 'Ships' },
-    { id: 3, name: 'Wood', item_code: 'wood', price: 5, category: 'Resources' },
-    { id: 4, name: 'Stone', item_code: 'stone', price: null, category: 'Materials' }
+    { id: 1, name: 'Longboat', item_id: 'longboat', price: 100, category: 'Ships' },
+    { id: 2, name: 'Broken Ship', item_id: 'broken_ship', price: 'abc', category: 'Ships' },
+    { id: 3, name: 'Wood', item_id: 'wood', price: 5, category: 'Resources' },
+    { id: 4, name: 'Stone', item_id: 'stone', price: null, category: 'Materials' }
   ];
 
   const dbStub = { query: async () => ({ rows }) };


### PR DESCRIPTION
## Summary
- Query the `shop` table directly, extracting `item_id` and metadata from JSON instead of relying on the `shop_v` view
- Update shop commands to work with `item_id` fields and propagate the value in responses
- Refresh tests to align with the new `shop` schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d57e86c0832eb12226f970f5d99d