### PR TITLE
Simplify shop item removal to report deleted rows

### DIFF
--- a/commands/shopCommands/removeitem.js
+++ b/commands/shopCommands/removeitem.js
@@ -13,10 +13,10 @@ module.exports = {
     ),
   async execute(interaction) {
     const itemName = interaction.options.getString('itemname');
-    const error = await shop.removeItem(itemName);
+    const removed = await shop.removeItem(itemName);
 
-    if (error) {
-      await interaction.reply(error);
+    if (removed === 0) {
+      await interaction.reply(`Item '${itemName}' was not found in the shop.`);
     } else {
       await interaction.reply(`Item '${itemName}' has been removed from the shop.`);
     }


### PR DESCRIPTION
## Summary
- Replace complex DELETE query with a simpler one that matches by item code, name, or row id and returns the number of rows deleted.
- Update removeitem command to use row count and provide a not-found message.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e0e38070832ea892e1ae77fc36d2