### PR TITLE
feat: persist stored items in database

### DIFF
--- a/commands/charCommands/grab.js
+++ b/commands/charCommands/grab.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const characters = require('../../db/characters');
 const items = require('../../db/items');
 const inventory = require('../../db/inventory');
-const { storageMap } = require('./store');
+const storage = require('../../db/storage');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -22,14 +22,12 @@ module.exports = {
             return interaction.reply({ content: err.message, ephemeral: true });
         }
 
-        const userStore = storageMap.get(userId) || {};
-        const storedQty = userStore[itemCode] || 0;
+        const storedQty = await storage.get(userId, itemCode);
         if (storedQty < qty) {
             return interaction.reply({ content: 'Not enough stored items.', ephemeral: true });
         }
 
-        userStore[itemCode] = storedQty - qty;
-        storageMap.set(userId, userStore);
+        await storage.retrieve(userId, itemCode, qty);
         await inventory.give(userId, itemCode, qty);
         return interaction.reply(`Retrieved ${qty} ${itemCode}.`);
     },

--- a/commands/charCommands/store.js
+++ b/commands/charCommands/store.js
@@ -2,8 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const characters = require('../../db/characters');
 const items = require('../../db/items');
 const inventory = require('../../db/inventory');
-
-const storageMap = new Map();
+const storage = require('../../db/storage');
 const cooldowns = new Map();
 
 module.exports = {
@@ -37,11 +36,8 @@ module.exports = {
         }
 
         await inventory.take(userId, itemCode, qty);
-        const userStore = storageMap.get(userId) || {};
-        userStore[itemCode] = (userStore[itemCode] || 0) + qty;
-        storageMap.set(userId, userStore);
+        await storage.store(userId, itemCode, qty);
 
         return interaction.reply(`Stored ${qty} ${itemCode}.`);
     },
-    storageMap,
 };

--- a/db/storage.js
+++ b/db/storage.js
@@ -1,0 +1,41 @@
+// db/storage.js
+const pool = require('../pg-client');
+
+async function store(ownerId, itemId, qty = 1) {
+  await pool.query(
+    `INSERT INTO storage_items (owner_id, item_id, quantity)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (owner_id, item_id)
+     DO UPDATE SET quantity = storage_items.quantity + EXCLUDED.quantity`,
+    [ownerId, itemId, qty]
+  );
+}
+
+async function retrieve(ownerId, itemId, qty = 1) {
+  const { rowCount } = await pool.query(
+    `UPDATE storage_items
+        SET quantity = quantity - $3
+      WHERE owner_id = $1 AND item_id = $2 AND quantity >= $3`,
+    [ownerId, itemId, qty]
+  );
+  if (!rowCount) return 0;
+  await pool.query(
+    `DELETE FROM storage_items WHERE owner_id = $1 AND item_id = $2 AND quantity <= 0`,
+    [ownerId, itemId]
+  );
+  return rowCount;
+}
+
+async function get(ownerId, itemId) {
+  const { rows } = await pool.query(
+    `SELECT quantity FROM storage_items WHERE owner_id = $1 AND item_id = $2`,
+    [ownerId, itemId]
+  );
+  return rows[0]?.quantity || 0;
+}
+
+module.exports = {
+  store,
+  retrieve,
+  get,
+};

--- a/migrations/006_create_storage_items.sql
+++ b/migrations/006_create_storage_items.sql
@@ -1,0 +1,6 @@
+CREATE TABLE storage_items (
+    owner_id TEXT NOT NULL,
+    item_id  TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    quantity INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (owner_id, item_id)
+);


### PR DESCRIPTION
## Summary
- add storage_items table to keep user item storage
- introduce db/storage helpers for storing and retrieving items
- update store and grab commands to use persistent storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e4a7ca8c832eaa36f1fd87621c3c