### PR TITLE
Use inventory.give in incomes transaction

### DIFF
--- a/commands/charCommands/incomes.js
+++ b/commands/charCommands/incomes.js
@@ -5,6 +5,7 @@ const clientManager = require('../../clientManager');
 const items = require('../../db/items');
 const shop = require('../../shop');
 const db = require('../../pg-client');
+const inventory = require('../../db/inventory');
 
 const cooldowns = new Map();
 
@@ -53,12 +54,7 @@ module.exports = {
                     );
                 }
                 if (inc.item_id && inc.item_amount > 0) {
-                    await t.query(
-                        `INSERT INTO inventory_items (instance_id, owner_id, item_id, durability, metadata)
-                         SELECT gen_random_uuid()::text, $1, $2, NULL, '{}'::jsonb
-                         FROM generate_series(1, $3)`,
-                        [userId, inc.item_id, inc.item_amount]
-                    );
+                    await inventory.give(userId, inc.item_id, inc.item_amount, t);
                 }
             });
 

--- a/db/inventory.js
+++ b/db/inventory.js
@@ -47,8 +47,9 @@ async function getCount(userId, itemCode) {
 }
 
 // insert qty rows; caller has validated item exists
-async function give(userId, itemCode, qty = 1) {
-  const { rows } = await pool.query(
+// optionally accepts a transaction/client with a query method
+async function give(userId, itemCode, qty = 1, client = pool) {
+  const { rows } = await client.query(
     `INSERT INTO inventory_items (instance_id, owner_id, item_id, durability, metadata)
      SELECT gen_random_uuid()::text, $1, $2, NULL, '{}'::jsonb
      FROM generate_series(1, $3)


### PR DESCRIPTION
## Summary
- Use `inventory.give` when distributing income items
- Allow `inventory.give` to accept an existing transaction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e612ded8832ebe62521da9893083