### PR TITLE
Add migration for storage_items table

### DIFF
--- a/migrations/007_create_storage_items.sql
+++ b/migrations/007_create_storage_items.sql
@@ -1,0 +1,6 @@
+CREATE TABLE storage_items (
+    owner_id TEXT NOT NULL,
+    item_id  TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    quantity INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (owner_id, item_id)
+);


### PR DESCRIPTION
## Summary
- duplicate storage_items table schema in new 007 migration

## Testing
- `psql "$DATABASE_URL" -f migrations/007_create_storage_items.sql`
- `node /tmp/test_store_grab.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f5189840832e81208e5855985322