### PR TITLE
Fix buy command to query JSON item_id

### DIFF
--- a/commands/shopCommands/buy.js
+++ b/commands/shopCommands/buy.js
@@ -28,7 +28,7 @@ module.exports = {
       `SELECT (data->>'price')::numeric AS price,
               data->>'item' AS name
          FROM shop
-        WHERE item_id = $1`,
+        WHERE data->>'item_id' = $1`,
       [itemId]
     );
     const row = rows[0];


### PR DESCRIPTION
## Summary
- Use `data->>'item_id'` when querying shop items in buy command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f6497e18832eb7a80662277ffbb6