### PR TITLE
refactor: simplify shop item lookup query

### DIFF
--- a/commands/shopCommands/buyitem.js
+++ b/commands/shopCommands/buyitem.js
@@ -6,12 +6,11 @@ async function findShopItem(term) {
   const { rows } = await pool.query(`
     SELECT id,
            data->>'item' AS name,
-           COALESCE(item_id, data->>'item_id') AS item_id,
+           data->>'item_id' AS item_id,
            (data->>'price')::numeric AS price,
            data->'infoOptions'->>'Category' AS category
       FROM shop
-     WHERE LOWER(item_id) = $1
-        OR LOWER(data->>'item_id') = $1
+     WHERE LOWER(data->>'item_id') = $1
         OR data->>'item' ILIKE $2
      LIMIT 1
   `, [term.toLowerCase(), term]);


### PR DESCRIPTION
## Summary
- query shop items using `data->>'item_id'` and drop legacy `item_id` column lookup
- simplify WHERE clause to match item by code or name

## Testing
- `node - <<'NODE' ... NODE`
- `npm test tests/resolve-item-code.test.js tests/buy-item-inventory.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0f70909e8832ebc4dbe6699e44238