### PR TITLE
fix deploycommands to avoid side effects

### DIFF
--- a/commands/adminCommands/deploycommands.js
+++ b/commands/adminCommands/deploycommands.js
@@ -1,5 +1,4 @@
 const { SlashCommandBuilder } = require('discord.js');
-const deployCommands = require('../../deploy-commands');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -7,6 +6,7 @@ module.exports = {
     .setDescription('Reload all slash commands')
     .setDefaultMemberPermissions(0),
   async execute(interaction) {
+    const deployCommands = require('../../deploy-commands');
     await deployCommands.loadCommands();
     await interaction.reply('Slash commands deployed.');
   },

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -69,6 +69,8 @@ async function loadCommands() {
 	})();
 }
 
-loadCommands();
+if (require.main === module) {
+        loadCommands();
+}
 
 module.exports = { loadCommands };


### PR DESCRIPTION
## Summary
- avoid executing `deploy-commands.js` on require
- lazily load deploycommands command to prevent spurious warnings

## Testing
- `node bot.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f7fb2648832e819b00cb172437ef