### PR TITLE
Resolve icons via metadata and clean command comments

### DIFF
--- a/archivedCommands/removeusecase.js
+++ b/archivedCommands/removeusecase.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const shop = require('../shop'); // Importing the database manager
+const shop = require('../shop');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/commands/adminCommands/addembed.js
+++ b/commands/adminCommands/addembed.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/addplayerkingdoms.js
+++ b/commands/adminCommands/addplayerkingdoms.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/editembedfield.js
+++ b/commands/adminCommands/editembedfield.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 ///editfield <field number> <new value>
 module.exports = {

--- a/commands/adminCommands/editembedmenu.js
+++ b/commands/adminCommands/editembedmenu.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/commands/adminCommands/embed.js
+++ b/commands/adminCommands/embed.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/embedlist.js
+++ b/commands/adminCommands/embedlist.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/guide.js
+++ b/commands/adminCommands/guide.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/commands/adminCommands/initclassselectmenu.js
+++ b/commands/adminCommands/initclassselectmenu.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/initpartyselectmenus.js
+++ b/commands/adminCommands/initpartyselectmenus.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/initresourceselectmenu.js
+++ b/commands/adminCommands/initresourceselectmenu.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/initshireselectmenu.js
+++ b/commands/adminCommands/initshireselectmenu.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/inittradenodeselectmenu.js
+++ b/commands/adminCommands/inittradenodeselectmenu.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/listplayerkingdoms.js
+++ b/commands/adminCommands/listplayerkingdoms.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/adminCommands/lore.js
+++ b/commands/adminCommands/lore.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/commands/adminCommands/map.js
+++ b/commands/adminCommands/map.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/commands/adminCommands/rank.js
+++ b/commands/adminCommands/rank.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/commands/adminCommands/removeembed.js
+++ b/commands/adminCommands/removeembed.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/commands/helpCommands/help.js
+++ b/commands/helpCommands/help.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/commands/helpCommands/helpadmin.js
+++ b/commands/helpCommands/helpadmin.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const admin = require('../../admin'); // Importing the database manager
+const admin = require('../../admin');
 const logger = require('../../logger');
 
 module.exports = {

--- a/shop.js
+++ b/shop.js
@@ -407,21 +407,17 @@ class shop {
 
   static async getItemIcon(itemName) {
     const res = await db.query(
-      `SELECT id,
-              data->>'item' AS name,
-              data->>'item_id' AS item_id,
-              (data->>'price')::numeric AS price,
-              data->'infoOptions'->>'Category' AS category
+      `SELECT data->'infoOptions'->>'Icon' AS icon
          FROM shop
         WHERE LOWER(data->>'item') = LOWER($1)
            OR LOWER(data->>'item_id') = LOWER($1)
-        ORDER BY name`,
+        ORDER BY data->>'item'`,
       [itemName]
     );
     if (!res.rows[0]) {
       return 'ERROR';
     }
-    return '';
+    return res.rows[0].icon || '';
   }
 
   static async getItemMetadata(itemId) {
@@ -430,18 +426,19 @@ class shop {
               data->>'item' AS name,
               data->>'item_id' AS item_id,
               (data->>'price')::numeric AS price,
-              data->'infoOptions'->>'Category' AS category
+              data->'infoOptions'->>'Category' AS category,
+              data->'infoOptions'->>'Icon' AS icon
          FROM shop
         WHERE LOWER(data->>'item') = LOWER($1)
            OR LOWER(data->>'item_id') = LOWER($1)
-        ORDER BY name`,
+        ORDER BY data->>'item'`,
       [itemId]
     );
     if (!res.rows[0]) return null;
     const row = res.rows[0];
     return {
       name: row.name,
-      icon: '',
+      icon: row.icon || '',
       category: row.category ?? 'Other',
       transferrable: '',
       usage: {},


### PR DESCRIPTION
## Summary
- use infoOptions Icon field for item icons in shop helpers
- drop obsolete database manager comments from command files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fa8656a4832e92baa6643a5dde9d